### PR TITLE
Tickets/preops 3616: Add airmass plot to prenight briefing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,5 @@ __version__ = "{version}"
 """
 
 [tool.pytest.ini_options]
-addopts = "--flake8 --black --ignore-glob=*/version.py"
-flake8-ignore = ["E133", "E203", "E226", "E228", "N802", "N803", "N806", "N812", "N813", "N815", "N816", "W503", "**/*/__init__.py ALL", "**/*/version.py ALL"]
-flake8-max-line-length = 110
-flake8-max-doc-length = 79
+addopts = "--black --ignore-glob=*/version.py"
 testpaths = "."

--- a/schedview/app/prenight/prenight.py
+++ b/schedview/app/prenight/prenight.py
@@ -20,6 +20,7 @@ import schedview.plot.rewards
 import schedview.plot.visits
 import schedview.plot.maf
 import schedview.plot.nightbf
+import schedview.plot.nightly
 import schedview.param
 
 import panel as pn
@@ -292,6 +293,31 @@ instance of rubin_sim.scheduler.conditions.Conditions."""
                 )
 
     @param.depends(
+        "_visits",
+        "_almanac_events",
+    )
+    def airmass_vs_time(self):
+        """Create a plot of airmass vs. time.
+
+        Returns
+        -------
+        fig : `bokeh.plotting.Figure`
+            The bokeh figure.
+        """
+        if self._visits is None:
+            return "No visits loaded."
+
+        if self._almanac_events is None:
+            self._update_almanac_events()
+
+        logging.info("Updating airmass vs. time plot")
+        fig = schedview.plot.nightly.plot_airmass_vs_time(
+            visits=self._visits, almanac_events=self._almanac_events
+        )
+        logging.info("Finished updating airmass vs. time plot")
+        return fig
+
+    @param.depends(
         "_scheduler",
         "_visits",
     )
@@ -562,6 +588,10 @@ def prenight_app(
             ),
         ),
         pn.Tabs(
+            (
+                "Airmass vs. time",
+                pn.param.ParamMethod(prenight.airmass_vs_time, loading_indicator=True),
+            ),
             (
                 "Visit explorer",
                 pn.param.ParamMethod(prenight.visit_explorer, loading_indicator=True),

--- a/schedview/plot/nightly.py
+++ b/schedview/plot/nightly.py
@@ -28,26 +28,66 @@ DEFAULT_EVENT_COLORS = {
     "night_middle": None,
 }
 
+
 def _visits_tooltips(visits, weather=False):
-    deg = u"\u00b0"
+    deg = "\u00b0"
     tooltips = [
-        ("Start time", "@start_date{%F %T} UTC (mjd=@observationStartMJD{00000.00}, LST=@observationStartLST"+deg+")"),
-        ('flush by mjd', '@flush_by_mjd{00000.00}'),
+        (
+            "Start time",
+            "@start_date{%F %T} UTC (mjd=@observationStartMJD{00000.00}, LST=@observationStartLST"
+            + deg
+            + ")",
+        ),
+        ("flush by mjd", "@flush_by_mjd{00000.00}"),
         ("Note", "@note"),
         ("Filter", "@filter"),
-        ("Field coordinates", "RA=@fieldRA"+deg+", Decl=@fieldDec"+deg+", Az=@azimuth"+deg+", Alt=@altitude"+deg),
-        ('Parallactic angle', '@paraAngle'+deg),
-        ("Rotator angle", "@rotTelPos"+deg),
-        ("Rotator angle (backup)", "@rotTelPos_backup"+deg),
-        ("Cumulative telescope azimuth", "@cummTelAz"+deg),
+        (
+            "Field coordinates",
+            "RA=@fieldRA"
+            + deg
+            + ", Decl=@fieldDec"
+            + deg
+            + ", Az=@azimuth"
+            + deg
+            + ", Alt=@altitude"
+            + deg,
+        ),
+        ("Parallactic angle", "@paraAngle" + deg),
+        ("Rotator angle", "@rotTelPos" + deg),
+        ("Rotator angle (backup)", "@rotTelPos_backup" + deg),
+        ("Cumulative telescope azimuth", "@cummTelAz" + deg),
         ("Airmass", "@airmass"),
-        ("Moon distance", "@moonDistance"+deg),     
-        ("Moon", "RA=@sunRA"+deg+", Decl=@sunDec"+deg+", Az=@sunAz"+deg+", Alt=@sunAlt"+deg + ", phase=@moonPhase"+deg),
-        ("Sun", "RA=@moonRA"+deg+", Decl=@moonDec"+deg+", Az=@moonAz"+deg+", Alt=@moonAlt"+deg + ", elong=@solarElong"+deg),
+        ("Moon distance", "@moonDistance" + deg),
+        (
+            "Moon",
+            "RA=@sunRA"
+            + deg
+            + ", Decl=@sunDec"
+            + deg
+            + ", Az=@sunAz"
+            + deg
+            + ", Alt=@sunAlt"
+            + deg
+            + ", phase=@moonPhase"
+            + deg,
+        ),
+        (
+            "Sun",
+            "RA=@moonRA"
+            + deg
+            + ", Decl=@moonDec"
+            + deg
+            + ", Az=@moonAz"
+            + deg
+            + ", Alt=@moonAlt"
+            + deg
+            + ", elong=@solarElong"
+            + deg,
+        ),
         ("Sky brightness", "@skyBrightness mag arcsec^-2"),
         ("Exposure time", "@visitExposureTime seconds (@numExposures exposures)"),
         ("Visit time", "@visitTime seconds"),
-        ("Slew distance", "@slewDistance"+deg),
+        ("Slew distance", "@slewDistance" + deg),
         ("Slew time", "@slewTime seconds"),
         ("Field ID", "@fieldId"),
         ("Proposal ID", "@proposalId"),
@@ -57,7 +97,10 @@ def _visits_tooltips(visits, weather=False):
 
     if weather:
         tooltips += [
-            ("Seeing", '@seeingFwhm500" (500nm), @seeingFwhmEff" (Eff), @seeingFwhmGeom" (Geom)'),
+            (
+                "Seeing",
+                '@seeingFwhm500" (500nm), @seeingFwhmEff" (Eff), @seeingFwhmGeom" (Geom)',
+            ),
             ("Cloud", "@cloud"),
             ("5-sigma depth", "@fiveSigmaDepth"),
         ]
@@ -83,6 +126,7 @@ def _add_almanac_events(fig, almanac_events, event_labels, event_colors):
             text_color=event_colors[event],
         )
         fig.add_layout(event_label)
+
 
 def plot_airmass_vs_time(
     visits,
@@ -145,13 +189,13 @@ def plot_airmass_vs_time(
         legend_field="filter",
         name="visit_airmass",
     )
-    
+
     hover_tool = bokeh.models.HoverTool()
     hover_tool.renderers = fig.select({"name": "visit_airmass"})
     hover_tool.tooltips = _visits_tooltips(visits)
-    hover_tool.formatters = {'@start_date': 'datetime'} 
+    hover_tool.formatters = {"@start_date": "datetime"}
     fig.add_tools(hover_tool)
-    
+
     plot_airmass_limit = np.round(np.max(visits.airmass), 1) + 0.1
     fig.y_range = bokeh.models.Range1d(plot_airmass_limit, 1)
     fig.xaxis[0].ticker = bokeh.models.DatetimeTicker()

--- a/schedview/plot/nightly.py
+++ b/schedview/plot/nightly.py
@@ -6,10 +6,10 @@ from .visitmap import BAND_COLORS
 
 DEFAULT_EVENT_LABELS = {
     "sunset": "sunset",
-    "sun_n12_setting": "sun alt=12" + "\u00B0",
-    "sun_n18_setting": "sun alt=18" + "\u00B0",
-    "sun_n18_rising": "sun alt=18" + "\u00B0",
-    "sun_n12_rising": "sun alt=12" + "\u00B0",
+    "sun_n12_setting": "sun alt=-12" + "\u00B0",
+    "sun_n18_setting": "sun alt=-18" + "\u00B0",
+    "sun_n18_rising": "sun alt=-18" + "\u00B0",
+    "sun_n12_rising": "sun alt=-12" + "\u00B0",
     "sunrise": "sunrise",
     "moonrise": "moonrise",
     "moonset": "moonset",
@@ -27,6 +27,42 @@ DEFAULT_EVENT_COLORS = {
     "moonset": "green",
     "night_middle": None,
 }
+
+def _visits_tooltips(visits, weather=False):
+    deg = u"\u00b0"
+    tooltips = [
+        ("Start time", "@start_date{%F %T} UTC (mjd=@observationStartMJD{00000.00}, LST=@observationStartLST"+deg+")"),
+        ('flush by mjd', '@flush_by_mjd{00000.00}'),
+        ("Note", "@note"),
+        ("Filter", "@filter"),
+        ("Field coordinates", "RA=@fieldRA"+deg+", Decl=@fieldDec"+deg+", Az=@azimuth"+deg+", Alt=@altitude"+deg),
+        ('Parallactic angle', '@paraAngle'+deg),
+        ("Rotator angle", "@rotTelPos"+deg),
+        ("Rotator angle (backup)", "@rotTelPos_backup"+deg),
+        ("Cumulative telescope azimuth", "@cummTelAz"+deg),
+        ("Airmass", "@airmass"),
+        ("Moon distance", "@moonDistance"+deg),     
+        ("Moon", "RA=@sunRA"+deg+", Decl=@sunDec"+deg+", Az=@sunAz"+deg+", Alt=@sunAlt"+deg + ", phase=@moonPhase"+deg),
+        ("Sun", "RA=@moonRA"+deg+", Decl=@moonDec"+deg+", Az=@moonAz"+deg+", Alt=@moonAlt"+deg + ", elong=@solarElong"+deg),
+        ("Sky brightness", "@skyBrightness mag arcsec^-2"),
+        ("Exposure time", "@visitExposureTime seconds (@numExposures exposures)"),
+        ("Visit time", "@visitTime seconds"),
+        ("Slew distance", "@slewDistance"+deg),
+        ("Slew time", "@slewTime seconds"),
+        ("Field ID", "@fieldId"),
+        ("Proposal ID", "@proposalId"),
+        ("Block ID", "@block_id"),
+        ("Scripted ID", "@scripted_id"),
+    ]
+
+    if weather:
+        tooltips += [
+            ("Seeing", '@seeingFwhm500" (500nm), @seeingFwhmEff" (Eff), @seeingFwhmGeom" (Geom)'),
+            ("Cloud", "@cloud"),
+            ("5-sigma depth", "@fiveSigmaDepth"),
+        ]
+
+    return tooltips
 
 
 def plot_airmass_vs_time(
@@ -88,7 +124,15 @@ def plot_airmass_vs_time(
         source=visits_ds,
         color={"field": "filter", "transform": filter_color_mapper},
         legend_field="filter",
+        name="visit_airmass",
     )
+    
+    hover_tool = bokeh.models.HoverTool()
+    hover_tool.renderers = fig.select({"name": "visit_airmass"})
+    hover_tool.tooltips = _visits_tooltips(visits)
+    hover_tool.formatters = {'@start_date': 'datetime'} 
+    fig.add_tools(hover_tool)
+    
     plot_airmass_limit = np.round(np.max(visits.airmass), 1) + 0.1
     fig.y_range = bokeh.models.Range1d(plot_airmass_limit, 1)
     fig.xaxis[0].ticker = bokeh.models.DatetimeTicker()

--- a/schedview/plot/nightly.py
+++ b/schedview/plot/nightly.py
@@ -1,0 +1,117 @@
+"""Plots that summarize a night's visits and other parameters."""
+
+import bokeh
+import numpy as np
+from .visitmap import BAND_COLORS
+
+DEFAULT_EVENT_LABELS = {
+    "sunset": "sunset",
+    "sun_n12_setting": "sun alt=12" + "\u00B0",
+    "sun_n18_setting": "sun alt=18" + "\u00B0",
+    "sun_n18_rising": "sun alt=18" + "\u00B0",
+    "sun_n12_rising": "sun alt=12" + "\u00B0",
+    "sunrise": "sunrise",
+    "moonrise": "moonrise",
+    "moonset": "moonset",
+    "night_middle": None,
+}
+
+DEFAULT_EVENT_COLORS = {
+    "sunset": "darkblue",
+    "sun_n12_setting": "blue",
+    "sun_n18_setting": "lightblue",
+    "sun_n18_rising": "lightblue",
+    "sun_n12_rising": "blue",
+    "sunrise": "darkblue",
+    "moonrise": "green",
+    "moonset": "green",
+    "night_middle": None,
+}
+
+
+def plot_airmass_vs_time(
+    visits,
+    almanac_events,
+    band_colors=BAND_COLORS,
+    event_labels=DEFAULT_EVENT_LABELS,
+    event_colors=DEFAULT_EVENT_COLORS,
+    figure=None,
+):
+    """Plot airmass vs. time for a set of visits
+
+    Parameters
+    ----------
+    visits : `pandas.DataFrame` or `bokeh.models.ColumnDataSource`
+        Dataframe or ColumnDataSource containing visit information.
+    almanac_events : `pandas.DataFrame`
+        Dataframe containing almanac events.
+    band_colors : `dict`
+        Mapping of filter names to colors.  Default is `BAND_COLORS`.
+    event_labels : `dict`
+        Mapping of almanac events to labels.  Default is `DEFAULT_EVENT_LABELS`.
+    event_colors : `dict`
+        Mapping of almanac events to colors.  Default is `DEFAULT_EVENT_COLORS`.
+    figure : `bokeh.plotting.Figure`
+        Bokeh figure object to plot on.  If None, a new figure will be created.
+
+    Returns
+    -------
+    fig : `bokeh.plotting.Figure`
+        Bokeh figure object
+    """
+
+    if figure is None:
+        fig = bokeh.plotting.figure(
+            title="Airmass",
+            x_axis_label="Time (UTC)",
+            y_axis_label="Airmass",
+            frame_width=768,
+            frame_height=512,
+        )
+    else:
+        fig = figure
+
+    if isinstance(visits, bokeh.models.ColumnDataSource):
+        visits_ds = visits
+    else:
+        visits_ds = bokeh.models.ColumnDataSource(visits)
+
+    filter_color_mapper = bokeh.models.CategoricalColorMapper(
+        factors=tuple(band_colors.keys()),
+        palette=tuple(band_colors.values()),
+        name="filter",
+    )
+    fig.line("start_date", "airmass", source=visits_ds, color="gray")
+    fig.circle(
+        "start_date",
+        "airmass",
+        source=visits_ds,
+        color={"field": "filter", "transform": filter_color_mapper},
+        legend_field="filter",
+    )
+    plot_airmass_limit = np.round(np.max(visits.airmass), 1) + 0.1
+    fig.y_range = bokeh.models.Range1d(plot_airmass_limit, 1)
+    fig.xaxis[0].ticker = bokeh.models.DatetimeTicker()
+    fig.xaxis[0].formatter = bokeh.models.DatetimeTickFormatter(hours="%H:%M")
+    fig.add_layout(fig.legend[0], "left")
+
+    if almanac_events is not None:
+        for event, row in almanac_events.iterrows():
+            if event_labels[event] is None:
+                continue
+
+            event_marker = bokeh.models.Span(
+                location=row.UTC, dimension="height", line_color=event_colors[event]
+            )
+            fig.add_layout(event_marker)
+            event_label = bokeh.models.Label(
+                x=row.UTC,
+                y=plot_airmass_limit,
+                text=" " + event_labels[event],
+                angle=90,
+                angle_units="deg",
+                text_color=event_colors[event],
+            )
+            fig.add_layout(event_label)
+
+    return fig

--- a/schedview/plot/nightly.py
+++ b/schedview/plot/nightly.py
@@ -65,6 +65,25 @@ def _visits_tooltips(visits, weather=False):
     return tooltips
 
 
+def _add_almanac_events(fig, almanac_events, event_labels, event_colors):
+    for event, row in almanac_events.iterrows():
+        if event_labels[event] is None:
+            continue
+
+        event_marker = bokeh.models.Span(
+            location=row.UTC, dimension="height", line_color=event_colors[event]
+        )
+        fig.add_layout(event_marker)
+        event_label = bokeh.models.Label(
+            x=row.UTC,
+            y=fig.y_range.start,
+            text=" " + event_labels[event],
+            angle=90,
+            angle_units="deg",
+            text_color=event_colors[event],
+        )
+        fig.add_layout(event_label)
+
 def plot_airmass_vs_time(
     visits,
     almanac_events,
@@ -140,22 +159,6 @@ def plot_airmass_vs_time(
     fig.add_layout(fig.legend[0], "left")
 
     if almanac_events is not None:
-        for event, row in almanac_events.iterrows():
-            if event_labels[event] is None:
-                continue
-
-            event_marker = bokeh.models.Span(
-                location=row.UTC, dimension="height", line_color=event_colors[event]
-            )
-            fig.add_layout(event_marker)
-            event_label = bokeh.models.Label(
-                x=row.UTC,
-                y=plot_airmass_limit,
-                text=" " + event_labels[event],
-                angle=90,
-                angle_units="deg",
-                text_color=event_colors[event],
-            )
-            fig.add_layout(event_label)
+        _add_almanac_events(fig, almanac_events, event_labels, event_colors)
 
     return fig

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -1,0 +1,53 @@
+import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+import importlib.resources
+import pandas as pd
+import bokeh
+
+from rubin_sim.scheduler.utils import SchemaConverter
+from rubin_sim.scheduler.model_observatory import ModelObservatory
+
+import schedview
+import schedview.plot.nightly
+
+
+def _load_sample_visits():
+    visits_path = (
+        importlib.resources.files(schedview)
+        .joinpath("data")
+        .joinpath("sample_opsim.db")
+    )
+    visits = pd.DataFrame(SchemaConverter().opsim2obs(visits_path))
+    if "observationStartMJD" not in visits.columns and "mjd" in visits.columns:
+        visits["observationStartMJD"] = visits["mjd"]
+
+    visits["start_date"] = pd.to_datetime(
+        visits["observationStartMJD"] + 2400000.5, origin="julian", unit="D", utc=True
+    )
+    return visits
+
+
+def _create_almanac(night):
+    site = ModelObservatory().location
+    timezone = "Chile/Continental"
+    almanac_events = schedview.compute.astro.night_events(night, site, timezone)
+    return almanac_events
+
+
+class test_nightly(unittest.TestCase):
+    def test_plot_airmass_vs_time(self):
+        visits = _load_sample_visits()
+        almanac_events = _create_almanac(visits["start_date"].dt.date[0])
+
+        fig = schedview.plot.nightly.plot_airmass_vs_time(visits, almanac_events)
+
+        with TemporaryDirectory() as dir:
+            out_path = Path(dir)
+            saved_html_fname = out_path.joinpath("test_page.html")
+            bokeh.plotting.output_file(filename=saved_html_fname, title="Test Page")
+            bokeh.plotting.save(fig)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a plot of airmass vs. time to the pre-night briefing, as requested by @edennihy. Includes a few bells and whistles, like a hover tool that shows additional information on each exposure and indicators of almanac events (-18° and -12° twilight, moon rise and set).
