### PR TITLE
Tickets/preops 3776

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,26 +1,36 @@
 Usage
 =====
 
-Running `sched_maps`
+Running `sceduler_dashboard`
 --------------------
 
-Activate the environment, and start the `bokeh` app. If `SCHEDVIEW_DIR` is the
-directory into which you cloned the `schedview` github repository, then
+Activate the conda environment and start the app:
 
 ::
 
     $ conda activate schedview
-    $ bokeh serve ${SCHEDVIEW_DIR}/schedview/app/sched_maps
+    $ scheduler_dashboard
 
 The app will then give you the URL at which you can find the app.
 
 Running `prenight`
 ------------------
 
-Activate the environment, and start the `bokeh` app. If `SCHEDVIEW_DIR` is the
-directory into which you cloned the `schedview` github repository, then:
+Activate the conda environment and start the app:
 
 ::
 
     $ conda activate schedview
-    $ python ${SCHEDVIEW_DIR}/schedview/app/prenight/prenight.py
+    $ prenight
+
+The app will then give you the URL at which you can find the app.
+
+You can also supply an initial set of data files to show on startup:
+
+::
+    $ conda activate schedview
+    $ prenight --night 2023-10-01 \
+    > --opsim_db /sdf/data/rubin/user/neilsen/devel/schedview/schedview/data/sample_opsim.db \
+    > --scheduler /sdf/data/rubin/user/neilsen/devel/schedview/schedview/data/sample_scheduler.pickle.xz \
+    > --rewards /sdf/data/rubin/user/neilsen/devel/schedview/schedview/data/sample_rewards.h5 \
+    > --port 8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ classifiers = [
  ]
 dynamic = [ "version" ]
 
+[project.scripts]
+prenight = "schedview.app.prenight.prenight:main"
+scheduler_dashboard = "schedview.app.scheduler_dashboard.scheduler_dashboard:main"
+
 [tool.setuptools.dynamic]
 version = { attr = "setuptools_scm.get_version" }
 

--- a/schedview/app/prenight/prenight.py
+++ b/schedview/app/prenight/prenight.py
@@ -1,5 +1,4 @@
 import argparse
-import importlib
 import json
 import logging
 import os
@@ -977,7 +976,7 @@ def parse_prenight_args():
     return prenight_app_parameters
 
 
-if __name__ == "__main__":
+def main():
     print("Starting prenight dashboard")
 
     prenight_app_parameters = parse_prenight_args()
@@ -1004,3 +1003,7 @@ if __name__ == "__main__":
         admin=True,
         profiler=True,
     )
+
+
+if __name__ == "__main__":
+    main()

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -23,6 +23,7 @@
 
 """schedview docstring"""
 
+import importlib.resources
 import logging
 import os
 import traceback
@@ -1453,13 +1454,15 @@ def scheduler_app(date=None, scheduler_pickle=None):
     return sched_app
 
 
-if __name__ == "__main__":
+def main():
     print("Starting scheduler dashboard.")
 
     if "SCHEDULER_PORT" in os.environ:
         scheduler_port = int(os.environ["SCHEDULER_PORT"])
     else:
         scheduler_port = 8080
+
+    assets_dir = os.path.join(importlib.resources.files("schedview"), "app", "scheduler_dashboard", "assets")
 
     pn.serve(
         scheduler_app,
@@ -1469,5 +1472,9 @@ if __name__ == "__main__":
         start=True,
         autoreload=True,
         threaded=True,
-        static_dirs={"assets": "./assets"},
+        static_dirs={"assets": assets_dir},
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Before, launching scripts required knowing the path to the python file, not something we want when they are installed as packages. This pull creates launch scripts on the path.