### PR TITLE
Revert "remove rubin_sim as a schedview dependency"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "healpy",
     "healsparse",
     "uranography >= 1.1.0 ",
+    "rubin_sim >= 1.3.0",
     "bokeh >= 3.1.1",
     "panel >= 1.1.0",
     "colorcet",


### PR DESCRIPTION
This reverts commit 12de4509eabe43767f6a3998075ae564669bbc34, which took out rubin_sim as a dependency.