### PR TITLE
accept nside, scheduler file name and mjd as url parameters

### DIFF
--- a/tests/test_scheduler_dashboard.py
+++ b/tests/test_scheduler_dashboard.py
@@ -89,12 +89,13 @@ class TestSchedulerDashboard(unittest.TestCase):
     def test_title(self):
         self.scheduler._tier = "tier 2"
         self.scheduler._survey = 0
+        self.scheduler._survey_name = "0: survey"
         self.scheduler._display_dashboard_data = True
         title = self.scheduler.generate_dashboard_subtitle()
         tier = self.scheduler._tier[-1]
         survey = self.scheduler._survey
         survey_map = self.scheduler.survey_map
-        expected_title = f"\nTier {tier} - Survey {survey} - Reward {survey_map}"
+        expected_title = f"\nTier {tier} - Survey {survey} - Map {survey_map}"
         self.assertEqual(title, expected_title)
 
     def test_make_summary_df(self):


### PR DESCRIPTION
This PR allows the scheduler dashboard to accept scheduler file name, nside and date mjd value as url paramaters.
- use `scheduler` to set scheduler file name (path or URL)
- use `nside` to set nside value
- use `mjd` to set date/time in mjd format

Example:
`http://localhost:8080?nside=16&scheduler=%2Fhome%2Feman%2FDownloads%2Fsched_maps%2Fexample_pickle_scheduler.p.xz&mjd=60207`
