### PR TITLE
Tickets/PREOPS-4401: Rewards table displays data for the wrong survey.

### DIFF
--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -525,11 +525,11 @@ class Scheduler(param.Parameterized):
             )
 
             # Duplicate column and apply URL formatting to one of the columns.
-            scheduler_summary_df["survey"] = scheduler_summary_df.loc[:, "survey_name"]
-            scheduler_summary_df["survey_name"] = scheduler_summary_df.apply(
+            scheduler_summary_df["survey"] = scheduler_summary_df.loc[:, "survey_name_with_id"]
+            scheduler_summary_df["survey_name_with_id"] = scheduler_summary_df.apply(
                 url_formatter,
                 axis=1,
-                args=("survey_name", "survey_url"),
+                args=("survey_name_with_id", "survey_url"),
             )
             self._scheduler_summary_df = scheduler_summary_df
 
@@ -563,21 +563,21 @@ class Scheduler(param.Parameterized):
             return
 
         self._debugging_message = "Starting to create summary widget."
-        tabulator_formatter = {"survey_name": HTMLTemplateFormatter(template="<%= value %>")}
+        tabulator_formatter = {"survey_name_with_id": HTMLTemplateFormatter(template="<%= value %>")}
         columns = [
             "tier",
-            "survey_name",
+            "survey_name_with_id",
             "reward",
             "survey",
             "survey_url",
         ]
         titles = {
-            "survey_name": "Survey",
+            "survey_name_with_id": "Survey",
             "reward": "Reward",
         }
         summary_widget = pn.widgets.Tabulator(
             self._scheduler_summary_df[self._scheduler_summary_df["tier"] == self._tier][columns],
-            widths={"survey_name": "60%", "reward": "40%"},
+            widths={"survey_name_with_id": "60%", "reward": "40%"},
             show_index=False,
             formatters=tabulator_formatter,
             titles=titles,
@@ -596,7 +596,7 @@ class Scheduler(param.Parameterized):
         self._debugging_message = "Starting to update summary widget."
         columns = [
             "tier",
-            "survey_name",
+            "survey_name_with_id",
             "reward",
             "survey",
             "survey_url",

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -566,18 +566,21 @@ class Scheduler(param.Parameterized):
         tabulator_formatter = {"survey_name_with_id": HTMLTemplateFormatter(template="<%= value %>")}
         columns = [
             "tier",
+            "survey_index",
             "survey_name_with_id",
             "reward",
             "survey",
             "survey_url",
         ]
         titles = {
+            "survey_index": "Index",
             "survey_name_with_id": "Survey",
             "reward": "Reward",
         }
         summary_widget = pn.widgets.Tabulator(
             self._scheduler_summary_df[self._scheduler_summary_df["tier"] == self._tier][columns],
-            widths={"survey_name_with_id": "60%", "reward": "40%"},
+            widths={"survey_index": "10%", "survey_name_with_id": "60%", "reward": "30%"},
+            text_align={"survey_index": "left", "survey_name": "left", "reward": "right"},
             show_index=False,
             formatters=tabulator_formatter,
             titles=titles,
@@ -596,6 +599,7 @@ class Scheduler(param.Parameterized):
         self._debugging_message = "Starting to update summary widget."
         columns = [
             "tier",
+            "survey_index",
             "survey_name_with_id",
             "reward",
             "survey",

--- a/schedview/compute/scheduler.py
+++ b/schedview/compute/scheduler.py
@@ -399,6 +399,8 @@ def make_scheduler_summary_df(scheduler, conditions, reward_df=None):
         survey_row = pd.Series({"reward": reward, "infeasible": infeasible})
         return survey_row
 
-    survey_df = summary_df.groupby(["tier", "survey_name_with_id", "survey_url"]).apply(make_survey_row)
+    survey_df = summary_df.groupby(
+        ["list_index", "survey_index", "survey_name_with_id", "survey_url", "tier"]
+    ).apply(make_survey_row)
 
     return survey_df["reward"].reset_index()

--- a/schedview/compute/scheduler.py
+++ b/schedview/compute/scheduler.py
@@ -378,7 +378,7 @@ def make_scheduler_summary_df(scheduler, conditions, reward_df=None):
         survey_name = make_unique_survey_name(scheduler, [row.list_index, row.survey_index])
         return survey_name
 
-    summary_df["survey_name"] = summary_df.apply(get_survey_name, axis=1)
+    summary_df["survey_name_with_id"] = summary_df.apply(get_survey_name, axis=1)
 
     def get_survey_url(row):
         if isinstance(row.survey_class, str):
@@ -399,6 +399,6 @@ def make_scheduler_summary_df(scheduler, conditions, reward_df=None):
         survey_row = pd.Series({"reward": reward, "infeasible": infeasible})
         return survey_row
 
-    survey_df = summary_df.groupby(["tier", "survey_name", "survey_url"]).apply(make_survey_row)
+    survey_df = summary_df.groupby(["tier", "survey_name_with_id", "survey_url"]).apply(make_survey_row)
 
     return survey_df["reward"].reset_index()


### PR DESCRIPTION
- Index fields added to df output by make_scheduler_summary_df() to maintain integer ordering.
- Index column added to scheduler summary table.
- Additionally, survey_name field changed to avoid overloading.