### PR TITLE
Tickets/preops 3846

### DIFF
--- a/schedview/app/prenight/prenight.py
+++ b/schedview/app/prenight/prenight.py
@@ -918,10 +918,10 @@ class RestrictedInputPrenight(Prenight):
 
         # make a dictionary of refereneces to the param paths, so that
         # they can be updated by key.
-        path_for_kwargs = {
-            "opsim_db": self.param["opsim_output_fname"].path,
-            "scheduler": self.param["scheduler_fname"].path,
-            "reward": self.param["rewards_fname"].path,
+        fname_params = {
+            "opsim_db": self.param["opsim_output_fname"],
+            "scheduler": self.param["scheduler_fname"],
+            "reward": self.param["rewards_fname"],
         }
 
         # In cases where the caller has not specified a value, set
@@ -935,11 +935,11 @@ class RestrictedInputPrenight(Prenight):
             }
 
         # Actually assign the names or globs to the path references.
-        for arg_name in path_for_kwargs:
+        for arg_name in fname_params:
             if arg_name in kwargs:
-                path_for_kwargs[arg_name] = kwargs[arg_name]
+                fname_params[arg_name].update(path=kwargs[arg_name])
             elif data_dir is not None:
-                path_for_kwargs[arg_name] = fname_glob[arg_name]
+                fname_params[arg_name].update(path=fname_glob[arg_name])
 
 
 def prenight_app(*args, **kwargs):
@@ -1125,7 +1125,7 @@ def main():
         return prenight_app(**prenight_app_parameters)
 
     pn.serve(
-        prenight_app_with_params,
+        {"schedview-prenight": prenight_app_with_params},
         port=prenight_port,
         title="Prenight Dashboard",
         show=show,

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -29,7 +29,7 @@ import logging
 import os
 import traceback
 
-# Filter the astropy warnings swamping the terminal
+# Filter the astropy warnings swamping the terminal.
 import warnings
 from datetime import datetime
 from glob import glob
@@ -48,7 +48,7 @@ from pandas import Timestamp
 from panel.io.loading import start_loading_spinner, stop_loading_spinner
 from pytz import timezone
 
-# For the conditions.mjd bugfix
+# For the conditions.mjd bugfix.
 from rubin_sim.scheduler.model_observatory import ModelObservatory
 
 import schedview
@@ -1576,10 +1576,6 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
         scheduler,
         parameters=["scheduler_fname", "widget_datetime", "widget_tier"],
         widgets={
-            "scheduler_fname": {
-                # "widget_type": pn.widgets.TextInput,
-                "placeholder": "filepath or URL of pickle",
-            },
             "widget_datetime": pn.widgets.DatetimePicker,
         },
         name="Select pickle file, date and tier.",

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -1514,8 +1514,8 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
     if scheduler_pickle is not None:
         scheduler.scheduler_fname = scheduler_pickle
 
-    from_urls = kwargs["data_from_urls"]
-    data_dir = kwargs["data_dir"]
+    from_urls = kwargs["data_from_urls"] if "data_from_urls" in kwargs.keys() else ""
+    data_dir = kwargs["data_dir"] if "data_dir" in kwargs.keys() else ""
 
     # Accept pickle files from url or any path.
     if from_urls:
@@ -1535,7 +1535,6 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
             )
     # Restrict files to data_directory.
     else:
-        pn.state.location.reload = False
         scheduler = RestrictedFilesScheduler(data_dir=data_dir)
         # This line is already in RestrictedFilesScheduler.__init__
         # but the selector path doesn't update without calling it here.

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -1514,7 +1514,7 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
     if scheduler_pickle is not None:
         scheduler.scheduler_fname = scheduler_pickle
 
-    from_urls = kwargs["data_from_urls"] if "data_from_urls" in kwargs.keys() else ""
+    from_urls = kwargs["data_from_urls"] if "data_from_urls" in kwargs.keys() else False
     data_dir = kwargs["data_dir"] if "data_dir" in kwargs.keys() else ""
 
     # Accept pickle files from url or any path.

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -58,7 +58,7 @@ import schedview.compute.survey
 import schedview.param
 import schedview.plot.survey
 
-# filter astropy warning that's filling the terminal with every update
+# filter astropy warning that's filling the terminal with every update.
 warnings.filterwarnings("ignore", category=AstropyWarning)
 
 DEFAULT_CURRENT_TIME = Time.now()
@@ -1287,7 +1287,7 @@ class Scheduler(param.Parameterized):
 
 class RestrictedFilesScheduler(Scheduler):
     """A Parametrized container for parameters, data, and panel objects for the
-    scheduler dashboard.
+    scheduler dashboard with restricted pickle file selection.
     """
 
     # Param parameters that are modifiable by user actions.
@@ -1509,21 +1509,21 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
     ).servable()
 
     scheduler = Scheduler()
-    # read scheduler_pickle if provided to the function in a notebook
-    # it will be overriden if the dashboard runs in an app
+    # read scheduler_pickle if provided to the function in a notebook.
+    # it will be overriden if the dashboard runs in an app.
     if scheduler_pickle is not None:
         scheduler.scheduler_fname = scheduler_pickle
 
     from_urls = kwargs["data_from_urls"]
     data_dir = kwargs["data_dir"]
 
-    # accept pickle files from url or any path
+    # Accept pickle files from url or any path.
     if from_urls:
-        # add placeholder text if the widget is a text input
-        # this cannot be done for a FileSelector parameter
+        # Add placeholder text if the widget is a text input.
+        # This cannot be done for a FileSelector parameter.
         pn.Param(scheduler, widgets={"scheduler_fname": {"placeholder": "filepath or URL of pickle"}})
 
-        # sync url parameters only if the files aren't restricted
+        # Sync url parameters only if the files aren't restricted.
         if pn.state.location is not None:
             pn.state.location.sync(
                 scheduler,
@@ -1533,18 +1533,18 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
                     "url_mjd": "mjd",
                 },
             )
-    # restrict files to data_directory
+    # Restrict files to data_directory.
     else:
         pn.state.location.reload = False
         scheduler = RestrictedFilesScheduler(data_dir=data_dir)
-        # this line is already in RestrictedFilesScheduler.__init__
-        # but the selector path doesn't update without calling it here
+        # This line is already in RestrictedFilesScheduler.__init__
+        # but the selector path doesn't update without calling it here.
         scheduler.param.scheduler_fname.path = data_dir
 
     if date_time is not None:
         scheduler.widget_datetime = date_time
 
-    # show dashboard as busy when scheduler.show_loading_spinner is True
+    # Show dashboard as busy when scheduler.show_loading_spinner is True.
     @pn.depends(loading=scheduler.param.show_loading_indicator, watch=True)
     def update_loading(loading):
         start_loading_spinner(sched_app) if loading else stop_loading_spinner(sched_app)
@@ -1648,9 +1648,7 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
 
 
 def parse_arguments():
-    """
-    Parse commandline arguments to read data directory if provided
-    """
+    """Parse commandline arguments to read data directory if provided."""
     parser = argparse.ArgumentParser(description="On-the-fly Rubin Scheduler dashboard")
     default_data_dir = f"{USDF_DATA_DIR}/*" if os.path.exists(USDF_DATA_DIR) else PACKAGE_DATA_DIR
 

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -1522,6 +1522,7 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
         del kwargs["data_dir"]
 
     scheduler = None
+    data_loading_widgets = {}
     # Accept pickle files from url or any path.
     if from_urls:
         scheduler = Scheduler()
@@ -1543,9 +1544,21 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
                     "url_mjd": "mjd",
                 },
             )
+
+        data_loading_widgets = {
+            "scheduler_fname": {
+                # "widget_type": pn.widgets.TextInput,
+                "placeholder": "filepath or URL of pickle",
+            },
+            "widget_datetime": pn.widgets.DatetimePicker,
+        }
+
     # Restrict files to data_directory.
     else:
         scheduler = RestrictedFilesScheduler(data_dir=data_dir)
+        data_loading_widgets = {
+            "widget_datetime": pn.widgets.DatetimePicker,
+        }
 
     # Show dashboard as busy when scheduler.show_loading_spinner is True.
     @pn.depends(loading=scheduler.param.show_loading_indicator, watch=True)
@@ -1578,15 +1591,10 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
     sched_app[8:33, 0:21] = pn.Param(
         scheduler,
         parameters=["scheduler_fname", "widget_datetime", "widget_tier"],
-        widgets={
-            # "scheduler_fname": {
-            #     # "widget_type": pn.widgets.TextInput,
-            #     "placeholder": "filepath or URL of pickle",
-            # },
-            "widget_datetime": pn.widgets.DatetimePicker,
-        },
+        widgets=data_loading_widgets,
         name="Select pickle file, date and tier.",
     )
+
     # Survey rewards table and header.
     sched_app[8:33, 21:67] = pn.Row(
         pn.Spacer(width=10),

--- a/schedview/param.py
+++ b/schedview/param.py
@@ -1,9 +1,12 @@
 # Subclasses of param.Parameter for use in schedview.
 
 import glob
+import os
+import pathlib
 
 import pandas as pd
 import param
+from param import Undefined
 
 
 class Series(param.Parameter):
@@ -88,11 +91,16 @@ class FileSelectorWithEmptyOption(param.FileSelector):
     Like param.FileSelector, but allows None to be deliberately selected.
     """
 
-    def update(self, path=None):
-        if path is not None and path != self.path:
-            self.path = path
-
-        self.objects = [""] + sorted(glob.glob(self.path))
+    def update(self, path=Undefined):
+        if path is Undefined:
+            path = self.path
+        if path == "":
+            self.objects = []
+        else:
+            # Convert using os.fspath and pathlib.Path to handle ensure
+            # the path separators are consistent (on Windows in particular)
+            pathpattern = os.fspath(pathlib.Path(path))
+            self.objects = [""] + sorted(glob.glob(pathpattern))
         if self.default in self.objects:
             return
         self.default = self.objects[0] if self.objects else None

--- a/tests/test_scheduler_dashboard.py
+++ b/tests/test_scheduler_dashboard.py
@@ -70,7 +70,7 @@ class TestSchedulerDashboard(unittest.TestCase):
         bokeh.io.reset_output()
 
     def test_scheduler_app(self):
-        sched_app = scheduler_app(date_time=TEST_DATE, scheduler_pickle=TEST_PICKLE)
+        sched_app = scheduler_app(date_time=TEST_DATE, scheduler_pickle=TEST_PICKLE, data_from_urls=True)
         sched_app_bokeh_model = sched_app.get_root()
         with TemporaryDirectory() as scheduler_dir:
             sched_out_path = Path(scheduler_dir)


### PR DESCRIPTION
added a subsclass of Scheduler that uses param FileSelector to restrict files to a certain directory, added a cli argument `--data_dir `to set data directory and choose between normal dahsboard behaviour or restricted one. URL paramaters don't work in restricted mode

add `--data_from_urls` argument to switch to non-restricted mode

Restricted mode is the default. If --data_dir isn't provided, files will be restricted what is in the `data` directory in the code base