### PR TITLE
tickets/PREOPS-4603: prepare schedview's scheduler_dashboard app for running at USDF w/ k8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN micromamba install -y -n base -f /home/${MAMBA_USER}/schedview/container_env
     micromamba clean --all --yes
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN python -m pip install /home/$MAMBA_USER/schedview --no-deps
+ARG TEST_DATA_DIR=/home/${MAMBA_USER}/schedview/test_data
+ARG TEST_DATA_INDEX=https://s3df.slac.stanford.edu/data/rubin/sim-data/sched_pickles/test_snapshots.html
+RUN mkdir -p ${TEST_DATA_DIR} && \
+    wget --no-parent --directory-prefix=${TEST_DATA_DIR} --no-directories --recursive ${TEST_DATA_INDEX}
 
 # Container execution
 ENV RUBIN_SIM_DATA_DIR=/home/${MAMBA_USER}/schedview/rubin_sim_data

--- a/container_environment.yaml
+++ b/container_environment.yaml
@@ -16,3 +16,4 @@ dependencies:
  - param
  - git
  - pip
+ - wget

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -1703,11 +1703,16 @@ def main():
     def scheduler_app_with_params():
         return scheduler_app(**commandline_args)
 
+    app_dict = {"dashboard": scheduler_app_with_params}
+    prefix = "/schedview-snapshot"
+    print(f"prefix: {prefix}, app_dict keys = {list(app_dict.keys())}")
+
     pn.serve(
-        scheduler_app_with_params,
+        app_dict,
         port=scheduler_port,
         title="Scheduler Dashboard",
-        show=True,
+        show=False,
+        prefix=prefix,
         start=True,
         autoreload=True,
         threaded=True,


### PR DESCRIPTION
The k8 ingress seems to have trouble getting supplying bokeh js libraries unless the dashboard is served a couple of directories "down" in the url, that is https://myhost/a/b works, but https://myhost and https://myhost/a do not.
There might be a way either to get bokeh to serve its libraries differently or get the ingress to handle routing to the js libraries, but I couldn't find it, and just moving the URL is easy and has no downsides that I can see.
I named the dir "scheduler-snapshot" here to make it clear how it is different from other existing planned or existing schedview dashboards, which can also be thought of as scheduler-related dashboards. What makes this dashboard distinctive is that it looks at the state of the scheduler as captured (in a pickle, at least for now) at a given time.