### PR TITLE
PREOPS-4838 Limiting the datetime selector’s range to those for which there are sky brightness files

### DIFF
--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -140,7 +140,7 @@ class Scheduler(param.Parameterized):
         doc=scheduler_fname_doc,
     )
     widget_datetime = param.Date(
-        default=DEFAULT_CURRENT_TIME.datetime.date(),
+        default=date_bounds[0],
         label="Date and time (UTC)",
         doc=f"Select dates between {date_bounds[0]} and {date_bounds[1]}",
         bounds=date_bounds,

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -88,14 +88,13 @@ stylesheet = """
 }
 """
 
-# Load available datetime range from SkyBrightness_Pre files
-sky_model = SkyModelPre()
-MIN_DATE = Time(sky_model.mjd_left.min(), format="mjd")
-MAX_DATE = Time(sky_model.mjd_right.max(), format="mjd")
-DATE_BOUNDS = (
-    MIN_DATE.to_datetime(),
-    MAX_DATE.to_datetime(),
-)
+
+def get_sky_brightness_date_bounds():
+    """Load available datetime range from SkyBrightness_Pre files"""
+    sky_model = SkyModelPre()
+    min_date = Time(sky_model.mjd_left.min(), format="mjd").to_datetime()
+    max_date = Time(sky_model.mjd_right.max(), format="mjd").to_datetime()
+    return (min_date, max_date)
 
 
 def url_formatter(dataframe_row, name_column, url_column):
@@ -131,6 +130,9 @@ class Scheduler(param.Parameterized):
     rubin_scheduler.scheduler.schedulers.CoreScheduler, and conditions is an
     instance of rubin_scheduler.scheduler.conditions.Conditions.
     """
+
+    _date_bounds = get_sky_brightness_date_bounds()
+
     scheduler_fname = param.String(
         default="",
         label="Scheduler pickle file",
@@ -139,8 +141,8 @@ class Scheduler(param.Parameterized):
     widget_datetime = param.Date(
         default=DEFAULT_CURRENT_TIME.datetime.date(),
         label="Date and time (UTC)",
-        doc=f"Select dates between {MIN_DATE.iso} and {MAX_DATE.iso}",
-        bounds=DATE_BOUNDS,
+        doc=f"Select dates between {_date_bounds[0]} and {_date_bounds[1]}",
+        bounds=_date_bounds,
     )
     url_mjd = param.Number(default=None)
     widget_tier = param.Selector(

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -92,8 +92,8 @@ stylesheet = """
 def get_sky_brightness_date_bounds():
     """Load available datetime range from SkyBrightness_Pre files"""
     sky_model = SkyModelPre()
-    min_date = Time(sky_model.mjd_left.min(), format="mjd").to_datetime()
-    max_date = Time(sky_model.mjd_right.max(), format="mjd").to_datetime()
+    min_date = Time(sky_model.mjd_left.min(), format="mjd")
+    max_date = Time(sky_model.mjd_right.max(), format="mjd")
     return (min_date, max_date)
 
 
@@ -131,7 +131,8 @@ class Scheduler(param.Parameterized):
     instance of rubin_scheduler.scheduler.conditions.Conditions.
     """
 
-    _date_bounds = get_sky_brightness_date_bounds()
+    (mjd_min, mjd_max) = get_sky_brightness_date_bounds()
+    date_bounds = (mjd_min.to_datetime(), mjd_max.to_datetime())
 
     scheduler_fname = param.String(
         default="",
@@ -141,8 +142,8 @@ class Scheduler(param.Parameterized):
     widget_datetime = param.Date(
         default=DEFAULT_CURRENT_TIME.datetime.date(),
         label="Date and time (UTC)",
-        doc=f"Select dates between {_date_bounds[0]} and {_date_bounds[1]}",
-        bounds=_date_bounds,
+        doc=f"Select dates between {date_bounds[0]} and {date_bounds[1]}",
+        bounds=date_bounds,
     )
     url_mjd = param.Number(default=None)
     widget_tier = param.Selector(

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -90,9 +90,11 @@ stylesheet = """
 
 # Load available datetime range from SkyBrightness_Pre files
 sky_model = SkyModelPre()
+MIN_DATE = Time(sky_model.mjd_left.min(), format="mjd")
+MAX_DATE = Time(sky_model.mjd_right.max(), format="mjd")
 DATE_BOUNDS = (
-    Time(sky_model.mjd_left.min(), format="mjd").to_datetime(),
-    Time(sky_model.mjd_right.max(), format="mjd").to_datetime(),
+    MIN_DATE.to_datetime(),
+    MAX_DATE.to_datetime(),
 )
 
 
@@ -135,7 +137,10 @@ class Scheduler(param.Parameterized):
         doc=scheduler_fname_doc,
     )
     widget_datetime = param.Date(
-        default=DEFAULT_CURRENT_TIME.datetime.date(), label="Date and time (UTC)", doc="", bounds=DATE_BOUNDS
+        default=DEFAULT_CURRENT_TIME.datetime.date(),
+        label="Date and time (UTC)",
+        doc=f"Select dates between {MIN_DATE.iso} and {MAX_DATE.iso}",
+        bounds=DATE_BOUNDS,
     )
     url_mjd = param.Number(default=None)
     widget_tier = param.Selector(

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard.py
@@ -50,6 +50,7 @@ from pytz import timezone
 
 # For the conditions.mjd bugfix
 from rubin_scheduler.scheduler.model_observatory import ModelObservatory
+from rubin_scheduler.skybrightness_pre.sky_model_pre import SkyModelPre
 
 import schedview
 import schedview.collect.scheduler_pickle
@@ -86,6 +87,13 @@ stylesheet = """
 --mono-font: Helvetica;
 }
 """
+
+# Load available datetime range from SkyBrightness_Pre files
+sky_model = SkyModelPre()
+DATE_BOUNDS = (
+    Time(sky_model.mjd_left.min(), format="mjd").to_datetime(),
+    Time(sky_model.mjd_right.max(), format="mjd").to_datetime(),
+)
 
 
 def url_formatter(dataframe_row, name_column, url_column):
@@ -127,9 +135,7 @@ class Scheduler(param.Parameterized):
         doc=scheduler_fname_doc,
     )
     widget_datetime = param.Date(
-        default=DEFAULT_CURRENT_TIME.datetime.date(),
-        label="Date and time (UTC)",
-        doc="",
+        default=DEFAULT_CURRENT_TIME.datetime.date(), label="Date and time (UTC)", doc="", bounds=DATE_BOUNDS
     )
     url_mjd = param.Number(default=None)
     widget_tier = param.Selector(

--- a/tests/test_scheduler_dashboard.py
+++ b/tests/test_scheduler_dashboard.py
@@ -18,10 +18,13 @@ from rubin_scheduler.scheduler.model_observatory import ModelObservatory
 
 # Objects to test instances against
 from rubin_scheduler.scheduler.schedulers.core_scheduler import CoreScheduler
-from rubin_scheduler.utils import survey_start_mjd
 
 import schedview
-from schedview.app.scheduler_dashboard.scheduler_dashboard import Scheduler, scheduler_app
+from schedview.app.scheduler_dashboard.scheduler_dashboard import (
+    Scheduler,
+    get_sky_brightness_date_bounds,
+    scheduler_app,
+)
 
 # Schedview methods
 from schedview.compute.scheduler import make_scheduler_summary_df
@@ -48,14 +51,14 @@ Tests I usually perform:
 
 
 Notes
------
 
     - Unit tests are not supposed to rely on each other.
     - Unit tests are run in alphabetical order.
 
 """
+
 TEST_PICKLE = str(importlib.resources.files(schedview).joinpath("data", "sample_scheduler.pickle.xz"))
-MJD_START = survey_start_mjd()
+MJD_START = get_sky_brightness_date_bounds()[0]
 TEST_DATE = Time(MJD_START + 0.2, format="mjd").datetime
 DEFAULT_TIMEZONE = "America/Santiago"
 


### PR DESCRIPTION
Get the date range covered by SkyBrightness_Pre data files and limit date picker to this range so that user cannot select outside the values that have data