### PR TITLE
install rubin-sim to get rubin-sim's data download too

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -29,7 +29,7 @@ jobs:
         id: rs-install
         shell: bash -l {0}
         run: |
-          mamba install --quiet rubin-scheduler
+          mamba install --quiet rubin-sim
           mamba list rubin-scheduler | grep -v "#" | awk '{print $2}' > ${{ github.workspace }}/rs_version
           echo "rs-version" `cat ${{ github.workspace }}/rs_version`
           echo "rs-version=`cat ${{ github.workspace }}/rs_version`" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Last update didn't include installing rubin-sim so as a result cache workflow didn't know about rs_download_data. now it does.