### PR TITLE
tickets/PREOPS-4896: make schedview's make_unique_survey_name more robust w.r.t. survey.observations type

### DIFF
--- a/schedview/compute/scheduler.py
+++ b/schedview/compute/scheduler.py
@@ -317,11 +317,12 @@ def make_unique_survey_name(scheduler, survey_index=None):
     except AttributeError:
         survey_name = str(survey)
 
-    if (
-        hasattr(survey, "observations")
-        and ("note" in survey.observations)
-        and (survey.survey_name != survey.observations["note"][0])
-    ):
+    try:
+        observation_note = f"{survey.observations['note'][0]}"
+    except (AttributeError, ValueError, TypeError):
+        observation_note = None
+
+    if (observation_note is not None) and (survey.survey_name != observation_note):
         survey_name = f"{survey.observations['note'][0]}"
 
     survey_name = f"{survey_index[1]}: {survey_name}"

--- a/schedview/compute/scheduler.py
+++ b/schedview/compute/scheduler.py
@@ -317,6 +317,10 @@ def make_unique_survey_name(scheduler, survey_index=None):
     except AttributeError:
         survey_name = str(survey)
 
+    # For auxtel, different fields have the same survey_name, but
+    # the interface should show the field name. So, if we're
+    # getting a field name in note, use that instead of the survey_name
+    # attribute.
     try:
         observation_note = f"{survey.observations['note'][0]}"
     except (AttributeError, ValueError, TypeError):


### PR DESCRIPTION
The `"note" in survey.observations` syntax doesn't work when survey.observations is a `numpy.recarray`, but it can be such in the new auxtel scheduler, and schedview really aught to handle this correctly. Using a try/except block lets schedview be more versatile. This is another instance of "better to ask forgiveness" being better than "look before you leap" in python.