### PR TITLE
tickets/PREOPS-4949: Move computations of some visit params to rubin_sim stackers

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,7 +28,7 @@ To add these additional packages, please install the following into your environ
   $ pip install lsst-resources
   $ conda install -c conda-forge lsst-efd-client
 
-  
+
 Installing with ``pip``
 -----------------------
 

--- a/schedview/collect/opsim.py
+++ b/schedview/collect/opsim.py
@@ -137,8 +137,8 @@ def read_opsim(
                 else:
                     raise e
 
-    if "start_date" in visits:
-        visits["start_date"] = pd.to_datetime(visits.start_date, unit="ns", utc=True)
+    if "observationStartDatetime64" in visits:
+        visits["start_date"] = pd.to_datetime(visits.observationStartDatetime64, unit="ns", utc=True)
 
     visits.set_index("observationId", inplace=True)
 

--- a/schedview/collect/opsim.py
+++ b/schedview/collect/opsim.py
@@ -5,7 +5,11 @@ import yaml
 from astropy.time import Time
 from lsst.resources import ResourcePath
 from rubin_scheduler.utils import ddf_locations
-from rubin_sim import maf
+
+try:
+    from rubin_sim import maf
+except ModuleNotFoundError:
+    pass
 
 DEFAULT_VISITS_COLUMNS = [
     "observationId",
@@ -56,42 +60,12 @@ DEFAULT_VISITS_COLUMNS = [
 ]
 
 
-class StartDateStacker(maf.BaseStacker):
-    """Add the start date."""
-
-    cols_added = ["start_date"]
-
-    def __init__(self, start_mjd_col="observationStartMJD"):
-        self.units = "ns"
-        self.cols_req = [start_mjd_col]
-        self.start_mjd_col = start_mjd_col
-
-    def _run(self, sim_data, cols_present=False):
-        """The start date as a datetime."""
-        if cols_present:
-            # Column already present in data; assume it is correct and does not
-            # need recalculating.
-            return sim_data
-        if len(sim_data) == 0:
-            return sim_data
-
-        sim_data["start_date"] = pd.to_datetime(
-            sim_data[self.start_mjd_col] + 2400000.5, origin="julian", unit="D", utc=True
-        )
-
-        return sim_data
-
-
-DEFAULT_STACKERS = [maf.HourAngleStacker(), StartDateStacker()]
-
-
 def read_opsim(
     opsim_uri,
     start_time=None,
     end_time=None,
     constraint=None,
     dbcols=DEFAULT_VISITS_COLUMNS,
-    stackers=DEFAULT_STACKERS,
     **kwargs,
 ):
     """Read visits from an opsim database.
@@ -108,8 +82,8 @@ def read_opsim(
         Query for which visits to load.
     dbcols : `list` [`str`]
         Columns required from the database.
-    stackers : `list` [`rubin_sim.maf.stackers`], optional
-        Stackers to be used to generate additional columns.
+    **kwargs
+        Passed to `maf.get_sim_data`, if `rubin_sim` is available.
 
     Returns
     -------
@@ -132,9 +106,6 @@ def read_opsim(
                 constraint += " AND "
             constraint += f"(observationStartMJD <= {Time(end_time).mjd})"
 
-    if stackers is not None and len(stackers) > 0:
-        kwargs["stackers"] = stackers
-
     original_resource_path = ResourcePath(opsim_uri)
 
     if original_resource_path.isdir():
@@ -150,7 +121,21 @@ def read_opsim(
 
     with obs_path.as_local() as local_obs_path:
         with sqlite3.connect(local_obs_path.ospath) as sim_connection:
-            visits = pd.DataFrame(maf.get_sim_data(sim_connection, constraint, dbcols, **kwargs))
+            try:
+                visits = pd.DataFrame(maf.get_sim_data(sim_connection, constraint, dbcols, **kwargs))
+            except NameError as e:
+                if e.name == "maf" and e.args == ("name 'maf' is not defined",):
+                    if len(kwargs) > 0:
+                        raise NotImplementedError(
+                            f"Argument {list(kwargs)[0]} not supported without rubin_sim installed"
+                        )
+
+                    query = f'SELECT {", ".join(dbcols)} FROM observations'
+                    if constraint:
+                        query += f" WHERE {constraint}"
+                    visits = pd.read_sql(query, sim_connection)
+                else:
+                    raise e
 
     if "start_date" in visits:
         visits["start_date"] = pd.to_datetime(visits.start_date, unit="ns", utc=True)
@@ -165,7 +150,6 @@ def read_ddf_visits(
     start_time=None,
     end_time=None,
     dbcols=DEFAULT_VISITS_COLUMNS,
-    stackers=DEFAULT_STACKERS,
     **kwargs,
 ):
     """Read DDF visits from an opsim database.
@@ -196,7 +180,6 @@ def read_ddf_visits(
         end_time=end_time,
         constraint=constraint,
         dbcols=dbcols,
-        stackers=stackers,
         **kwargs,
     )
     return visits

--- a/schedview/collect/opsim.py
+++ b/schedview/collect/opsim.py
@@ -137,8 +137,15 @@ def read_opsim(
                 else:
                     raise e
 
-    if "observationStartDatetime64" in visits:
-        visits["start_date"] = pd.to_datetime(visits.observationStartDatetime64, unit="ns", utc=True)
+            if "start_date" not in visits:
+                if "observationStartDatetime64" in visits:
+                    visits["start_date"] = pd.to_datetime(
+                        visits.observationStartDatetime64, unit="ns", utc=True
+                    )
+                elif "observationStartMJD" in visits:
+                    visits["start_date"] = pd.to_datetime(
+                        visits.observationStartMJD + 2400000.5, origin="julian", unit="D", utc=True
+                    )
 
     visits.set_index("observationId", inplace=True)
 

--- a/schedview/compute/__init__.py
+++ b/schedview/compute/__init__.py
@@ -17,7 +17,6 @@ __all__ = [
 
 from .astro import convert_evening_date_to_night_of_survey, night_events
 from .camera import LsstCameraFootprintPerimeter
-from .maf import compute_hpix_metric_in_bands, compute_metric_by_visit
 from .scheduler import (
     compute_basis_function_reward_at_time,
     compute_basis_function_rewards,
@@ -27,3 +26,9 @@ from .scheduler import (
     replay_visits,
 )
 from .survey import compute_maps, make_survey_reward_df
+
+try:
+    from .maf import compute_hpix_metric_in_bands, compute_metric_by_visit
+except ModuleNotFoundError as e:
+    if not e.args == ("No module named 'rubin_sim'",):
+        raise e

--- a/schedview/compute/maf.py
+++ b/schedview/compute/maf.py
@@ -6,7 +6,7 @@ import pandas as pd
 from rubin_scheduler.scheduler.utils import SchemaConverter
 from rubin_sim import maf
 
-__all__ = ["compute_metric_by_visit", "StartDateStacker"]
+__all__ = ["compute_metric_by_visit"]
 
 
 def _visits_to_opsim(visits, opsim):
@@ -110,29 +110,3 @@ def compute_hpix_metric_in_bands(visits, metric, constraint="", nside=32):
     metric_values = {b: bundles[b].metric_values for b in bundles if bundles[b].metric_values is not None}
 
     return metric_values
-
-
-class StartDateStacker(maf.BaseStacker):
-    """Add the start date."""
-
-    cols_added = ["start_date"]
-
-    def __init__(self, start_mjd_col="observationStartMJD"):
-        self.units = "ns"
-        self.cols_req = [start_mjd_col]
-        self.start_mjd_col = start_mjd_col
-
-    def _run(self, sim_data, cols_present=False):
-        """The start date as a datetime."""
-        if cols_present:
-            # Column already present in data; assume it is correct and does not
-            # need recalculating.
-            return sim_data
-        if len(sim_data) == 0:
-            return sim_data
-
-        sim_data["start_date"] = pd.to_datetime(
-            sim_data[self.start_mjd_col] + 2400000.5, origin="julian", unit="D", utc=True
-        )
-
-        return sim_data

--- a/schedview/compute/visits.py
+++ b/schedview/compute/visits.py
@@ -3,7 +3,6 @@ import datetime
 import numpy as np
 from astropy.time import Time
 from rubin_scheduler.site_models import SeeingModel
-from rubin_sim import maf
 
 import schedview.compute
 
@@ -209,19 +208,23 @@ def accum_teff_by_night(visits):
         exposure times for all exposures with that target on that night.
     """
     day_obs_col = "day_obs_iso8601"
-    teff_col = "teff"
+    teff_col = "t_eff"
 
     if day_obs_col not in visits:
-        visits = add_day_obs(visits.copy())
+        raise ValueError(
+            f"{day_obs_col} column not found for visits; use the rubin_sim.maf.stackers.DayObsISOStacker."
+        )
 
     if teff_col not in visits:
-        visits = add_maf_metric(visits.copy(), maf.TeffMetric(), "teff")
+        raise ValueError(
+            f"{teff_col} column not found for visits; use the rubin_sim.maf.stackers.TeffStacker."
+        )
 
     nightly_teff = visits.groupby(["target", day_obs_col, "filter"])[teff_col].sum().reset_index()
     nightly_teff = (
         nightly_teff.pivot(index=["target", day_obs_col], columns="filter", values=teff_col)
         .fillna(0.0)
         .reset_index()
-        .set_index(["target", "day_obs_iso8601"])
+        .set_index(["target", day_obs_col])
     )
     return nightly_teff

--- a/tests/test_compute_maf.py
+++ b/tests/test_compute_maf.py
@@ -3,14 +3,20 @@ import unittest
 import numpy as np
 from rubin_scheduler.data import get_baseline
 from rubin_scheduler.utils import survey_start_mjd
-from rubin_sim import maf
 
 from schedview.collect import read_opsim
-from schedview.compute import compute_hpix_metric_in_bands, compute_metric_by_visit
+
+try:
+    from rubin_sim import maf
+
+    from schedview.compute import compute_hpix_metric_in_bands, compute_metric_by_visit
+except ModuleNotFoundError:
+    pass
 
 
 class TestComputeMAF(unittest.TestCase):
 
+    @unittest.skipUnless("maf" in locals(), "No maf installation")
     def test_compute_metric_by_visit(self):
         visits = read_opsim(get_baseline())
         mjd_start = survey_start_mjd()
@@ -21,6 +27,7 @@ class TestComputeMAF(unittest.TestCase):
         self.assertGreater(np.min(values), 0.0)
         self.assertLess(np.max(values), 300)
 
+    @unittest.skipUnless("maf" in locals(), "No maf installation")
     def test_compute_hpix_metric_in_bands(self):
         visits = read_opsim(get_baseline())
         mjd_start = survey_start_mjd()

--- a/tests/test_compute_visits.py
+++ b/tests/test_compute_visits.py
@@ -4,10 +4,14 @@ import numpy as np
 from astropy.time import Time
 from rubin_scheduler.data import get_baseline
 from rubin_scheduler.utils import survey_start_mjd
-from rubin_sim import maf
 
 import schedview.collect
 import schedview.compute.visits
+
+try:
+    from rubin_sim import maf
+except ModuleNotFoundError:
+    pass
 
 
 class TestComputeVisits(unittest.TestCase):
@@ -19,16 +23,11 @@ class TestComputeVisits(unittest.TestCase):
         end_time = Time(start_mjd + 1, format="mjd")
         self.visits = schedview.collect.read_opsim(self.visit_db_fname, start_time, end_time)
 
-    def test_add_day_obs(self):
-        visits = schedview.compute.visits.add_day_obs(self.visits)
-        self.assertEqual(visits.columns[1], "day_obs_mjd")
-        self.assertEqual(visits.columns[2], "day_obs_date")
-        self.assertEqual(visits.columns[3], "day_obs_iso8601")
-
     def test_add_coords_tuple(self):
         visits = schedview.compute.visits.add_coords_tuple(self.visits)
         self.assertEqual(len(visits["coords"].iloc[0]), 2)
 
+    @unittest.skipUnless("maf" in locals(), "No maf installation")
     def test_add_maf_metric(self):
         constraint = None
         visits = schedview.compute.visits.add_maf_metric(
@@ -36,17 +35,13 @@ class TestComputeVisits(unittest.TestCase):
         )
         self.assertIn("teff", visits.columns)
 
-    def test_add_overhead(self):
-        visits = schedview.compute.visits.add_overhead(self.visits)
-        self.assertIn("overhead", visits.columns)
-        self.assertIn("previous_filter", visits.columns)
-
     def test_add_instrumental_fwhm(self):
         visits = schedview.compute.visits.add_instrumental_fwhm(self.visits)
         self.assertTrue(np.all(visits.seeingFwhmEff > visits.inst_fwhm))
         self.assertTrue(np.all(visits.inst_fwhm > 0))
         self.assertIn("inst_fwhm", visits.columns)
 
+    @unittest.skipUnless("maf" in locals(), "No maf installation")
     def test_accum_teff_by_night(self):
         stackers = [
             maf.stackers.ObservationStartDatetime64Stacker(),

--- a/tests/test_compute_visits.py
+++ b/tests/test_compute_visits.py
@@ -48,7 +48,13 @@ class TestComputeVisits(unittest.TestCase):
         self.assertIn("inst_fwhm", visits.columns)
 
     def test_accum_teff_by_night(self):
-        visits = schedview.collect.read_ddf_visits(self.visit_db_fname)
+        stackers = [
+            maf.stackers.ObservationStartDatetime64Stacker(),
+            maf.stackers.TeffStacker(),
+            maf.stackers.DayObsISOStacker(),
+        ]
+
+        visits = schedview.collect.read_ddf_visits(self.visit_db_fname, stackers=stackers)
         night_teff = schedview.compute.visits.accum_teff_by_night(visits)
         self.assertEqual(night_teff.index.names[0], "target")
         self.assertEqual(night_teff.index.names[1], "day_obs_iso8601")

--- a/tests/test_plot_cadence.py
+++ b/tests/test_plot_cadence.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import bokeh.models.layouts
 import numpy as np
 from rubin_scheduler.data import get_baseline
+from rubin_sim import maf
 
 import schedview.collect
 import schedview.compute.visits
@@ -12,8 +13,14 @@ from schedview.plot import create_cadence_plot
 class TestPlotCadence(TestCase):
 
     def test_create_cadence_plot(self):
+        stackers = [
+            maf.stackers.ObservationStartDatetime64Stacker(),
+            maf.stackers.TeffStacker(),
+            maf.stackers.DayObsISOStacker(),
+        ]
+
         visit_db_fname = get_baseline()
-        visits = schedview.collect.read_ddf_visits(visit_db_fname)
+        visits = schedview.collect.read_ddf_visits(visit_db_fname, stackers=stackers)
         night_totals = schedview.compute.visits.accum_teff_by_night(visits)
         start_dayobs_mjd = np.floor(visits.observationStartMJD.min())
         end_dayobs_mjd = start_dayobs_mjd + 365

--- a/tests/test_plot_cadence.py
+++ b/tests/test_plot_cadence.py
@@ -1,17 +1,23 @@
+import unittest
 from unittest import TestCase
 
 import bokeh.models.layouts
 import numpy as np
 from rubin_scheduler.data import get_baseline
-from rubin_sim import maf
 
 import schedview.collect
 import schedview.compute.visits
 from schedview.plot import create_cadence_plot
 
+try:
+    from rubin_sim import maf
+except ModuleNotFoundError:
+    pass
+
 
 class TestPlotCadence(TestCase):
 
+    @unittest.skipUnless("maf" in locals(), "No rubin_sim.maf installation")
     def test_create_cadence_plot(self):
         stackers = [
             maf.stackers.ObservationStartDatetime64Stacker(),


### PR DESCRIPTION
This PR also include changes for PREOPS-4990, which let the scheduler snapshot dashboard run without rubin_sim installed.