### PR TITLE
tickects/PREOPS-5067: Add basis function and survey rewards timeline plots that do not use python callbacks

### DIFF
--- a/schedview/plot/__init__.py
+++ b/schedview/plot/__init__.py
@@ -6,6 +6,9 @@ __all__ = [
     "plot_polar_alt_az",
     "plot_survey_rewards",
     "create_survey_reward_plot",
+    "reward_timeline_for_tier",
+    "area_timeline_for_tier",
+    "reward_timeline_for_surveys",
     "make_logger",
     "BadSchedulerError",
     "BadConditionsError",
@@ -33,7 +36,13 @@ from .colors import PLOT_FILTER_CMAP, PLOT_FILTER_COLORS
 from .nightbf import plot_infeasible, plot_rewards
 from .nightly import plot_airmass_vs_time, plot_alt_vs_time, plot_polar_alt_az
 from .overhead import create_overhead_histogram, create_overhead_summary_table, plot_overhead_vs_slew_distance
-from .rewards import create_survey_reward_plot, plot_survey_rewards
+from .rewards import (
+    area_timeline_for_tier,
+    create_survey_reward_plot,
+    plot_survey_rewards,
+    reward_timeline_for_surveys,
+    reward_timeline_for_tier,
+)
 from .scheduler import (
     BadConditionsError,
     BadSchedulerError,

--- a/schedview/plot/nightly.py
+++ b/schedview/plot/nightly.py
@@ -1,6 +1,7 @@
 """Plots that summarize a night's visits and other parameters."""
 
 import bokeh
+import bokeh.models
 import colorcet
 import numpy as np
 
@@ -258,8 +259,12 @@ def plot_alt_vs_time(
         Bokeh figure object
     """
     for time_column in "start_date", "observationStartDatetime64":
-        if time_column in visits:
-            break
+        if isinstance(visits, bokeh.models.ColumnDataSource):
+            if time_column in visits.data:
+                break
+        else:
+            if time_column in visits:
+                break
 
     if figure is None:
         fig = bokeh.plotting.figure(

--- a/schedview/plot/nightly.py
+++ b/schedview/plot/nightly.py
@@ -257,6 +257,9 @@ def plot_alt_vs_time(
     fig : `bokeh.plotting.Figure`
         Bokeh figure object
     """
+    for time_column in "start_date", "observationStartDatetime64":
+        if time_column in visits:
+            break
 
     if figure is None:
         fig = bokeh.plotting.figure(
@@ -294,10 +297,10 @@ def plot_alt_vs_time(
         name="filter",
     )
 
-    fig.line("start_date", "altitude", source=visits_ds, color="gray")
+    fig.line(time_column, "altitude", source=visits_ds, color="gray")
     if too_many_note_values:
         fig.scatter(
-            "start_date",
+            time_column,
             "altitude",
             source=visits_ds,
             marker={"field": "filter", "transform": filter_marker_mapper},
@@ -307,7 +310,7 @@ def plot_alt_vs_time(
         )
     else:
         fig.scatter(
-            "start_date",
+            time_column,
             "altitude",
             source=visits_ds,
             color={"field": "note", "transform": note_color_mapper},

--- a/schedview/plot/rewards.py
+++ b/schedview/plot/rewards.py
@@ -15,6 +15,14 @@ import schedview.collect.scheduler_pickle
 import schedview.compute.astro
 import schedview.compute.scheduler
 
+__all__ = [
+    "plot_survey_rewards",
+    "create_survey_reward_plot",
+    "reward_timeline_for_tier",
+    "area_timeline_for_tier",
+    "reward_timeline_for_surveys",
+]
+
 
 def plot_survey_rewards(rewards):
     """Plot survey rewards as a function of time.

--- a/schedview/plot/rewards.py
+++ b/schedview/plot/rewards.py
@@ -116,14 +116,51 @@ def make_timeline_bars(
     factor_column,
     value_column,
     value_range_min=-np.inf,
+    value_range_max=np.inf,
     user_infeasible_kwargs=None,
     user_max_kwargs=None,
-    value_range_max=np.inf,
     user_plot_kwargs={},
     user_rect_dict={},
     cmap=None,
 ):
+    """Create a stacked set of timelines with vertical colored bars.
 
+    Parameters
+    ----------
+    df : `pandas.DataFrame`
+        The table of the data to plot.
+    factor_column : `str`
+        The name of the column determining the horizontal line on which
+        values will be plotted.
+    value_column : `str`
+        The name of the column to map to bar height and color.
+    value_range_min : `float`
+        The low extreme value for height and color mapping.
+        Defaults to `-numpy.inf`.
+    value_range_max : `float`
+        The high extreme value for height and color mapping.
+        Defaults to `-numpy.inf`.
+    user_infeasible_kwargs : `dict` or `None`
+        Keyword arguments passed to `bokeh.plotting.figure.scatter` for
+        points flagged infeasible. Defaults to `None`.
+    user_max_kwargs : `dict` or `None`
+        Keyword arguments passed to `bokeh.plotting.figure.scatter` for
+        points with values higher than the range.
+        Defaults to `None`.
+    user_plot_kwargs : `dict` or `None`
+        Keyword arguments passed to `bokeh.plotting.figure` when creating
+        the instantiating it.
+    user_rect_kwargs : `dict` or `None`
+        Keyword arguments passed to `bokeh.plotting.figure.rect` for
+        points within range.
+    cmap : `Sequence` [`bokeh.colors.ColorLike`]
+        The color map to use to color the rectangles.
+
+    Returns
+    -------
+    `plot` : `bokeh.models.layouts.LayoutDOM`
+        The plot that can be shown or saved.
+    """
     # Make the data source
     data_source = bokeh.models.ColumnDataSource(df)
     data_source.data["datetime"] = pd.to_datetime(df.queue_start_mjd + 2400000.5, origin="julian", unit="D")
@@ -300,6 +337,27 @@ def make_timeline_bars(
 
 
 def reward_timeline_for_tier(rewards_df, tier, day_obs_mjd, show=True, **figure_kwargs):
+    """Plot the reward timeline for basis functions in a specified tier.
+
+    Parameters
+    ----------
+    rewards_df : `pandas.DataFrame`
+        The table of rewards data.
+    tier : `int`
+        The tier index, corresponding to the index of
+        `rubin_scheduler.scheduler.schedulers.CoreScheduler.survey_lists`.
+    day_obs_mjd : `int`
+        The MJD of the day_obs of the night to plot.
+    show : `bool`
+        Actually show the plot? Defaults to `True`.
+    **figure_kwargs
+        Keyword arguments passed to `bokeh.plotting.figure`.
+
+    Returns
+    -------
+    `plot` : `bokeh.models.layouts.LayoutDOM`
+        The plot that can be shown or saved.
+    """
     rewards_df = rewards_df.query(
         f'tier_label == "tier {tier}" and floor(queue_start_mjd-0.5)=={day_obs_mjd}'
     ).copy()
@@ -330,6 +388,27 @@ def reward_timeline_for_tier(rewards_df, tier, day_obs_mjd, show=True, **figure_
 
 
 def area_timeline_for_tier(rewards_df, tier, day_obs_mjd, show=True, **figure_kwargs):
+    """Plot the feasible area timeline for basis funcs in a specified tier.
+
+    Parameters
+    ----------
+    rewards_df : `pandas.DataFrame`
+        The table of rewards data.
+    tier : `int`
+        The tier index, corresponding to the index of
+        `rubin_scheduler.scheduler.schedulers.CoreScheduler.survey_lists`.
+    day_obs_mjd : `int`
+        The MJD of the day_obs of the night to plot.
+    show : `bool`
+        Actually show the plot? Defaults to `True`.
+    **figure_kwargs
+        Keyword arguments passed to `bokeh.plotting.figure`.
+
+    Returns
+    -------
+    `plot` : `bokeh.models.layouts.LayoutDOM`
+        The plot that can be shown or saved.
+    """
     rewards_df = rewards_df.query(
         f'tier_label == "tier {tier}" and floor(queue_start_mjd-0.5)=={day_obs_mjd}'
     ).copy()
@@ -373,6 +452,24 @@ def area_timeline_for_tier(rewards_df, tier, day_obs_mjd, show=True, **figure_kw
 
 
 def reward_timeline_for_surveys(rewards_df, day_obs_mjd, show=True, **figure_kwargs):
+    """Plot the reward timeline for all surveys.
+
+    Parameters
+    ----------
+    rewards_df : `pandas.DataFrame`
+        The table of rewards data.
+    day_obs_mjd : `int`
+        The MJD of the day_obs of the night to plot.
+    show : `bool`
+        Actually show the plot? Defaults to `True`.
+    **figure_kwargs
+        Keyword arguments passed to `bokeh.plotting.figure`.
+
+    Returns
+    -------
+    `plot` : `bokeh.models.layouts.LayoutDOM`
+        The plot that can be shown or saved.
+    """
     survey_rewards_df = (
         rewards_df.groupby(["list_index", "survey_index", "queue_start_mjd", "queue_fill_mjd_ns"])
         .agg(

--- a/schedview/plot/rewards.py
+++ b/schedview/plot/rewards.py
@@ -4,6 +4,7 @@ import bokeh
 import colorcet
 import holoviews as hv
 import numpy as np
+import pandas as pd
 from astropy.time import Time
 
 # Imported to help sphinx make the link
@@ -123,6 +124,7 @@ def make_timeline_bars(
 
     # Make the data source
     data_source = bokeh.models.ColumnDataSource(df)
+    data_source.data["datetime"] = pd.to_datetime(df.queue_start_mjd + 2400000.5, origin="julian", unit="D")
 
     # Make the figure
     if "y_range" not in user_plot_kwargs:
@@ -133,11 +135,14 @@ def make_timeline_bars(
         factor_range = user_plot_kwargs["y_range"]
 
     plot_kwargs = {
-        "x_axis_label": "MJD",
+        "x_axis_label": "Time",
+        "x_axis_type": "datetime",
         "y_range": factor_range,
     }
     plot_kwargs.update(user_plot_kwargs)
     plot = bokeh.plotting.figure(**plot_kwargs)
+
+    plot.xaxis[0].formatter = bokeh.models.DatetimeTickFormatter(hours="%H:%M")
 
     # Make the reward limit range slider
     values = df[value_column].values
@@ -205,7 +210,7 @@ def make_timeline_bars(
 
     # Put rectangles on the plot
     rect_kwargs = dict(
-        x="queue_start_mjd",
+        x="datetime",
         y=factor_column,
         width=30.0 / (24 * 60 * 60),
         height=height_map,
@@ -220,7 +225,7 @@ def make_timeline_bars(
         infeasible = np.logical_or(infeasible, np.logical_not(df.feasible))
 
     plot.scatter(
-        x="queue_start_mjd",
+        x="datetime",
         y=factor_column,
         marker="x",
         color="red",
@@ -230,7 +235,7 @@ def make_timeline_bars(
     )
 
     plot.scatter(
-        x="queue_start_mjd",
+        x="datetime",
         y=factor_column,
         marker="triangle",
         color="black",

--- a/schedview/plot/rewards.py
+++ b/schedview/plot/rewards.py
@@ -134,14 +134,23 @@ def make_timeline_bars(
     else:
         factor_range = user_plot_kwargs["y_range"]
 
+    hover_tool = bokeh.models.HoverTool(
+        tooltips=[
+            ("Time", "@datetime{%Y-%m-%d %H:%M:%S}"),
+            ("MJD", "@queue_start_mjd{00000.000}"),
+            (value_column, f"@{value_column}"),
+        ],
+        formatters={"@datetime": "datetime"},
+    )
+
     plot_kwargs = {
         "x_axis_label": "Time",
         "x_axis_type": "datetime",
         "y_range": factor_range,
+        "tools": ["pan", "wheel_zoom", "box_zoom", "save", "reset", "help", hover_tool],
     }
     plot_kwargs.update(user_plot_kwargs)
     plot = bokeh.plotting.figure(**plot_kwargs)
-
     plot.xaxis[0].formatter = bokeh.models.DatetimeTickFormatter(hours="%H:%M")
 
     # Make the reward limit range slider
@@ -212,7 +221,7 @@ def make_timeline_bars(
     rect_kwargs = dict(
         x="datetime",
         y=factor_column,
-        width=30.0 / (24 * 60 * 60),
+        width=pd.Timedelta(30, unit="s"),
         height=height_map,
         color=cmap,
         source=data_source,

--- a/tests/test_plot_rewards.py
+++ b/tests/test_plot_rewards.py
@@ -1,0 +1,63 @@
+import importlib.resources
+import os
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import bokeh
+
+import schedview
+import schedview.collect.rewards
+import schedview.plot.rewards
+
+WRITE_TIMEOUT_SECONDS = 20
+
+
+class TestPlotRewards(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = TemporaryDirectory()
+        cls.temp_path = Path(cls.temp_dir.name)
+
+        # Even though this seems unnecessary given the filename argument used
+        # in verify_can_plot, without it tests fail when they are run in CI
+        # by github (but run locally).
+        saved_html_fname = cls.temp_path.joinpath(f"test_plot_rewards_{time.time()}.html").name
+        bokeh.plotting.output_file(filename=saved_html_fname, title="This Test Page")
+
+    def verify_can_plot(self, plot):
+        saved_html_fname = self.temp_path.joinpath(f"can_verify_plot_test_{time.time()}.html").name
+        bokeh.io.save(plot, filename=saved_html_fname)
+        waited_time_seconds = 0
+        while waited_time_seconds < WRITE_TIMEOUT_SECONDS and not os.path.isfile(saved_html_fname):
+            time.sleep(1)
+
+    def setUp(self):
+        rewards_rp = importlib.resources.files("schedview").joinpath("data").joinpath("sample_rewards.h5")
+        self.rewards_df, self.obs_reward = schedview.collect.rewards.read_rewards(rewards_rp)
+        self.tier = 3
+        self.day_obs_mjd = int(self.rewards_df["queue_start_mjd"].min() - 0.5)
+
+    def test_reward_timeline_for_tier(self):
+        plot = schedview.plot.rewards.reward_timeline_for_tier(
+            self.rewards_df, tier=self.tier, day_obs_mjd=self.day_obs_mjd
+        )
+        self.verify_can_plot(plot)
+
+    def test_area_timeline_for_tier(self):
+        plot = schedview.plot.rewards.area_timeline_for_tier(
+            self.rewards_df, tier=self.tier, day_obs_mjd=self.day_obs_mjd
+        )
+        self.verify_can_plot(plot)
+
+    def test_reward_timeline_for_surveys(self):
+        plot = schedview.plot.rewards.reward_timeline_for_surveys(
+            self.rewards_df, day_obs_mjd=self.day_obs_mjd
+        )
+        self.verify_can_plot(plot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Needed to support adding such plots to the Times Square pre-night briefing.