### PR TITLE
PREOPS-5239: Switch schedview from using bokeh.plotting.figure.circle to bokeh.plotting.figure.scatter with marker=circle

### DIFF
--- a/schedview/plot/overhead.py
+++ b/schedview/plot/overhead.py
@@ -126,14 +126,14 @@ def plot_overhead_vs_slew_distance(visits, plot=None, **kwargs):
             x_axis_label="slew distance (deg.)",
         )
 
-    circle_kwargs = {"color": PLOT_FILTER_CMAP, "fill_alpha": 0.3}
+    circle_kwargs = {"color": PLOT_FILTER_CMAP, "fill_alpha": 0.3, "marker": "circle"}
     circle_kwargs.update(kwargs)
 
     for band in PLOT_FILTER_CMAP.transform.factors:
         these_visits = visits.query(f'filter == "{band}"')
 
         if len(these_visits) > 0:
-            plot.circle(
+            plot.scatter(
                 x="slewDistance", y="overhead", source=these_visits, legend_label=band, **circle_kwargs
             )
 

--- a/schedview/plot/visits.py
+++ b/schedview/plot/visits.py
@@ -90,13 +90,13 @@ def plot_visit_param_vs_time(visits, column_name, plot=None, **kwargs):
     if plot is None:
         plot = bokeh.plotting.figure(y_axis_label=column_name, x_axis_label="Time (UTC)")
 
-    circle_kwargs = {"fill_alpha": 0.3}
+    circle_kwargs = {"fill_alpha": 0.3, "marker": "circle"}
     circle_kwargs.update(kwargs)
 
     for band in PLOT_FILTER_CMAP.transform.factors:
         these_visits = visits.query(f'filter == "{band}"')
         if len(these_visits) > 0:
-            plot.circle(
+            plot.scatter(
                 x="start_date",
                 y=column_name,
                 color=PLOT_FILTER_CMAP,


### PR DESCRIPTION
bokeh.plotting.figure.circle is sometimes throwing deprecation warnings, and sometimes silently just not plotting points (with the latest version of bokeh).