### PR TITLE
tickets/PREOPS-5245: Add support for reading visits from ConsDB

### DIFF
--- a/schedview/collect/consdb.py
+++ b/schedview/collect/consdb.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pandas as pd
+import rubin_sim.maf
+from rubin_scheduler.utils.consdb import load_consdb_visits
+
+
+def read_consdb(
+    instrument: str = "lsstcomcamsim",
+    *args,
+    stackers: list[rubin_sim.maf.stackers.base_stacker.BaseStacker] = [],
+    **kwargs,
+) -> pd.DataFrame:
+    consdb_visits = load_consdb_visits(instrument, *args, **kwargs)
+    visit_records: np.recarray = consdb_visits.opsim.to_records()
+    for stacker in stackers:
+        visit_records = stacker.run(visit_records)
+    visits = pd.DataFrame(visit_records)
+    return visits

--- a/tests/test_consdb.py
+++ b/tests/test_consdb.py
@@ -8,6 +8,7 @@ from schedview.collect.consdb import read_consdb
 
 class TestConsdb(unittest.TestCase):
 
+    @unittest.skip("avoid requiring access to consdb for tests.")
     def test_consdb_read_consdb(self):
         day_obs: str = "2024-06-26"
         stackers = [

--- a/tests/test_consdb.py
+++ b/tests/test_consdb.py
@@ -1,0 +1,20 @@
+import unittest
+
+import pandas as pd
+from rubin_sim import maf
+
+from schedview.collect.consdb import read_consdb
+
+
+class TestConsdb(unittest.TestCase):
+
+    def test_consdb_read_consdb(self):
+        day_obs: str = "2024-06-26"
+        stackers = [
+            maf.stackers.OverheadStacker(),
+            maf.HourAngleStacker(),
+            maf.stackers.ObservationStartDatetime64Stacker(),
+        ]
+        visits: pd.DataFrame = read_consdb("lsstcomcamsim", day_obs, stackers=stackers)
+        assert "HA" in visits.columns
+        assert "overhead" in visits.columns


### PR DESCRIPTION
This will only work after the merge of a corresponding PR in rubin_scheduler.