### PR TITLE
tickets/PREOPS-5539: Highlight winning survey on snapshot dashboard

### DIFF
--- a/schedview/app/scheduler_dashboard/scheduler_dashboard_app.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard_app.py
@@ -217,7 +217,7 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
         reset_button
     )
     # Summary table and header.
-    sched_app[8 : scheduler.data_params_grid_height + 6, 21:67] = pn.Row(
+    sched_app[8 : scheduler.data_params_grid_height, 21:67] = pn.Row(
         pn.Spacer(width=10),
         pn.Column(
             pn.Spacer(height=10),
@@ -228,6 +228,11 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
             pn.param.ParamMethod(scheduler.publish_summary_widget, loading_indicator=True),
         ),
         pn.Spacer(width=10),
+    )
+    # Selected survey label.
+    sched_app[scheduler.data_params_grid_height : scheduler.data_params_grid_height + 6, 21:67] = pn.Row(
+        scheduler.selected_survey_label,
+        styles={"background": "#048b8c"},
     )
     # Reward table and header.
     sched_app[scheduler.data_params_grid_height + 6 : scheduler.data_params_grid_height + 45, 0:67] = pn.Row(

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard_app.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard_app.py
@@ -216,23 +216,16 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
     sched_app[scheduler.data_params_grid_height : scheduler.data_params_grid_height + 6, 3:15] = pn.Row(
         reset_button
     )
-    # Selected survey label.
-    sched_app[8 : 12, 21:67] = pn.Row(
+    # Summary table and header + chosen survey label.
+    sched_app[8 : scheduler.data_params_grid_height + 6, 21:67] = pn.Row(
         pn.Spacer(width=10),
         pn.Column(
             pn.Spacer(height=10),
             pn.Row(
-                scheduler.selected_survey_label,
+                scheduler.chosen_survey_label,
                 styles={"background": "#045D5D"},
             ),
-        ),
-        pn.Spacer(width=10),
-    )
-    # Summary table and header.
-    sched_app[12 : scheduler.data_params_grid_height, 21:67] = pn.Row(
-        pn.Spacer(width=10),
-        pn.Column(
-            # pn.Spacer(height=10),
+            pn.Spacer(height=10),
             pn.Row(
                 scheduler.summary_table_heading,
                 styles={"background": "#048b8c"},

--- a/schedview/app/scheduler_dashboard/scheduler_dashboard_app.py
+++ b/schedview/app/scheduler_dashboard/scheduler_dashboard_app.py
@@ -216,11 +216,23 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
     sched_app[scheduler.data_params_grid_height : scheduler.data_params_grid_height + 6, 3:15] = pn.Row(
         reset_button
     )
-    # Summary table and header.
-    sched_app[8 : scheduler.data_params_grid_height, 21:67] = pn.Row(
+    # Selected survey label.
+    sched_app[8 : 12, 21:67] = pn.Row(
         pn.Spacer(width=10),
         pn.Column(
             pn.Spacer(height=10),
+            pn.Row(
+                scheduler.selected_survey_label,
+                styles={"background": "#045D5D"},
+            ),
+        ),
+        pn.Spacer(width=10),
+    )
+    # Summary table and header.
+    sched_app[12 : scheduler.data_params_grid_height, 21:67] = pn.Row(
+        pn.Spacer(width=10),
+        pn.Column(
+            # pn.Spacer(height=10),
             pn.Row(
                 scheduler.summary_table_heading,
                 styles={"background": "#048b8c"},
@@ -228,11 +240,6 @@ def scheduler_app(date_time=None, scheduler_pickle=None, **kwargs):
             pn.param.ParamMethod(scheduler.publish_summary_widget, loading_indicator=True),
         ),
         pn.Spacer(width=10),
-    )
-    # Selected survey label.
-    sched_app[scheduler.data_params_grid_height : scheduler.data_params_grid_height + 6, 21:67] = pn.Row(
-        scheduler.selected_survey_label,
-        styles={"background": "#048b8c"},
     )
     # Reward table and header.
     sched_app[scheduler.data_params_grid_height + 6 : scheduler.data_params_grid_height + 45, 0:67] = pn.Row(

--- a/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
+++ b/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
@@ -207,13 +207,11 @@ class SchedulerSnapshotDashboard(param.Parameterized):
 
         # Current fix for _conditions.mjd having different datatypes.
         if isinstance(self._conditions._mjd, np.ndarray):
-            print("self._conditions._mjd is np.ndarray")
             self._conditions._mjd = self._conditions._mjd[0]
 
         # Get mjd from pickle and set widget and URL to match.
         self._do_not_trigger_update = True
         self.url_mjd = self._conditions._mjd
-        print(type(self._conditions._mjd))
         self.widget_datetime = Time(self._conditions._mjd, format="mjd").to_datetime()
         self._do_not_trigger_update = False
 

--- a/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
+++ b/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
@@ -1248,7 +1248,11 @@ class SchedulerSnapshotDashboard(param.Parameterized):
         if not self._display_dashboard_data:
             return "Chosen survey is ..."
         self._scheduler.request_observation()
-        label = self._reward_df.loc[tuple(self._scheduler.survey_index), ("tier_label", "survey_label")].drop_duplicates().values
+        label = (
+            self._reward_df.loc[tuple(self._scheduler.survey_index), ("tier_label", "survey_label")]
+            .drop_duplicates()
+            .values
+        )
         tier_label = label[0][0]
         survey_label = label[0][1]
         return f"Chosen survey is {tier_label}, {survey_label}."

--- a/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
+++ b/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
@@ -1368,8 +1368,8 @@ class SchedulerSnapshotDashboard(param.Parameterized):
         if not self._display_dashboard_data:
             return ""
         self._scheduler.request_observation()
-        tier_label, survey_label = self._reward_df.loc[tuple(self._scheduler.survey_index), ("tier", "survey")].drop_duplicates().values
-        return f"Chosen survey was {tier_label}, {survey_label}."
+        label = self._reward_df.loc[tuple(self._scheduler.survey_index), ("tier_label", "survey_label")].drop_duplicates().values
+        return f"Chosen survey is {label[0][0]}, {label[0][1]}."
 
     @param.depends("_update_headings")
     def selected_survey_label(self):

--- a/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
+++ b/schedview/app/scheduler_dashboard/unrestricted_scheduler_snapshot_dashboard.py
@@ -111,6 +111,7 @@ class SchedulerSnapshotDashboard(param.Parameterized):
     summary_table_heading_pane = None
     reward_table_heading_pane = None
     map_title_pane = None
+    selected_survey_label_pane = None
 
     # Non-Param internal parameters.
     _mjd = None
@@ -1361,3 +1362,25 @@ class SchedulerSnapshotDashboard(param.Parameterized):
         else:
             self.map_title_pane.object = title_string
         return self.map_title_pane
+
+    def generate_selected_survey_label(self):
+
+        if not self._display_dashboard_data:
+            return ""
+        self._scheduler.request_observation()
+        tier_label, survey_label = self._reward_df.loc[tuple(self._scheduler.survey_index), ("tier", "survey")].drop_duplicates().values
+        return f"Chosen survey was {tier_label}, {survey_label}."
+
+    @param.depends("_update_headings")
+    def selected_survey_label(self):
+        """DOCSTRING
+        """
+        selected_survey_string = self.generate_selected_survey_label()
+        if self.selected_survey_label_pane is None:
+            self.selected_survey_label_pane = pn.pane.Str(
+                selected_survey_string,
+                stylesheets=[h3_stylesheet],
+            )
+        else:
+            self.selected_survey_label_pane.object = selected_survey_string
+        return self.selected_survey_label_pane


### PR DESCRIPTION
To highlight which survey is "chosen" for a particular snapshot, a dynamic label has been created with the text "Chosen survey is ... ". This label is updated to display the "chosen" tier and survey whenever a new snapshot is loaded.

The label sits above the Scheduler Summary table header on a dark teal background.

<img width="1484" alt="chosen survey label" src="https://github.com/user-attachments/assets/f1312202-967a-4068-916c-65974c3fa99a">
