### PR TITLE
tickets/SP-1792: Pin rubin_scheduler to 3.4.0

### DIFF
--- a/container_environment.yaml
+++ b/container_environment.yaml
@@ -18,7 +18,7 @@ dependencies:
  - boto3
  - wget
  - lsst-efd-client
- - rubin-scheduler
+ - rubin-scheduler = 3.4.0
  - rubin-sim
  - pip
  - pip:


### PR DESCRIPTION
Once this is merged, I can tag a new schedview (0.16.0) and create a new container, then push to phalanx.
This will sweep up a few more changes to schedview into 0.16.0, but I think that's okay.