### PR TITLE
SP-1864: Swap target to target_name in DDF constraint

### DIFF
--- a/schedview/collect/opsim.py
+++ b/schedview/collect/opsim.py
@@ -211,7 +211,7 @@ def read_ddf_visits(
     visits : `pandas.DataFrame`
         The visits and their parameters.
     """
-    ddf_field_names = tuple(ddf_locations().keys())
+    ddf_field_names = [f"DD:{field_name}" for field_name in ddf_locations().keys()]
     # Note that this where clause is hard-coded for target_name (v4+)
     # but other columns in query will be backwards-compatible.
     constraint = f"target_name IN {tuple(field_name for field_name in ddf_field_names)}"

--- a/schedview/collect/opsim.py
+++ b/schedview/collect/opsim.py
@@ -212,7 +212,9 @@ def read_ddf_visits(
         The visits and their parameters.
     """
     ddf_field_names = tuple(ddf_locations().keys())
-    constraint = f"target IN {tuple(field_name for field_name in ddf_field_names)}"
+    # Note that this where clause is hard-coded for target_name (v4+)
+    # but other columns in query will be backwards-compatible.
+    constraint = f"target_name IN {tuple(field_name for field_name in ddf_field_names)}"
     visits = read_opsim(
         opsim_uri,
         start_time=start_time,

--- a/schedview/collect/opsim.py
+++ b/schedview/collect/opsim.py
@@ -211,16 +211,33 @@ def read_ddf_visits(
     visits : `pandas.DataFrame`
         The visits and their parameters.
     """
-    ddf_field_names = [f"DD:{field_name}" for field_name in ddf_locations().keys()]
-    # Note that this where clause is hard-coded for target_name (v4+)
-    # but other columns in query will be backwards-compatible.
-    constraint = f"target_name IN {tuple(field_name for field_name in ddf_field_names)}"
-    visits = read_opsim(
-        opsim_uri,
-        start_time=start_time,
-        end_time=end_time,
-        constraint=constraint,
-        dbcols=dbcols,
-        **kwargs,
-    )
+    try:
+        ddf_field_names = [f"DD:{field_name}" for field_name in ddf_locations().keys()]
+        # Note that this where clause is hard-coded for target_name (v4+)
+        # but other columns in query will be backwards-compatible.
+        constraint = f"target_name IN {tuple(field_name for field_name in ddf_field_names)}"
+        visits = read_opsim(
+            opsim_uri,
+            start_time=start_time,
+            end_time=end_time,
+            constraint=constraint,
+            dbcols=dbcols,
+            **kwargs,
+        )
+    except pd.errors.DatabaseError:
+        # Older database use 'target' not target_name and does not include DD
+        ddf_field_names = [f"{field_name}" for field_name in ddf_locations().keys()]
+        # Note that this where clause is hard-coded for target_name (v4+)
+        # but other columns in query will be backwards-compatible.
+        constraint = f"target IN {tuple(field_name for field_name in ddf_field_names)}"
+        visits = read_opsim(
+            opsim_uri,
+            start_time=start_time,
+            end_time=end_time,
+            constraint=constraint,
+            dbcols=dbcols,
+            **kwargs,
+        )
+        # There are even older databases which do not use target at all,
+        # but we'll leave those for now.
     return visits


### PR DESCRIPTION
The constraint for read_ddf_visits used "target" (old column name) instead of "target_name" (new column name). 
Many other uses of opsim are backward compatible, but it's not obvious how to make this particular use backward compatible unless you retrieve all visits and then sub-select afterwards, or query table first to check for columns .. essentially doing the work that is done in the next step of "read_opsim", and I didn't want to duplicate code. 
