### PR TITLE
Update rubin_scheduler dependency in schedview container to 3.8.0

### DIFF
--- a/container_environment.yaml
+++ b/container_environment.yaml
@@ -18,7 +18,7 @@ dependencies:
  - boto3
  - wget
  - lsst-efd-client
- - rubin-scheduler = 3.6.0
+ - rubin-scheduler = 3.8.0
  - rubin-sim
  - scikit-learn
  - pip


### PR DESCRIPTION
Presently running the snapshot dashboard on usdf-int, seems to work even though the scheduler running at the observatory is still 3.7.0.