### PR TITLE
tickets/SP-2228: add hovertext to DDF cadence plots

### DIFF
--- a/schedview/examples/ddfcadence.py
+++ b/schedview/examples/ddfcadence.py
@@ -52,7 +52,7 @@ def make_ddf_cadence_plot(
         )
 
     # Compute
-    nightly_ddf = schedview.compute.visits.accum_teff_by_night(visits)
+    nightly_ddf = schedview.compute.visits.accum_stats_by_target_band_night(visits)
 
     # Plot
     result: bokeh.models.UIElement = schedview.plot.create_cadence_plot(

--- a/tests/test_compute_visits.py
+++ b/tests/test_compute_visits.py
@@ -48,7 +48,7 @@ class TestComputeVisits(unittest.TestCase):
         self.assertIn("inst_fwhm", visits.columns)
 
     @unittest.skipUnless("maf" in locals(), "No maf installation")
-    def test_accum_teff_by_night(self):
+    def test_accum_stats_by_target_band_night(self):
         stackers = [
             maf.stackers.ObservationStartDatetime64Stacker(),
             maf.stackers.TeffStacker(),
@@ -56,7 +56,7 @@ class TestComputeVisits(unittest.TestCase):
         ]
 
         visits = schedview.collect.read_ddf_visits(self.visit_db_fname, stackers=stackers)
-        night_teff = schedview.compute.visits.accum_teff_by_night(visits)
+        night_teff = schedview.compute.visits.accum_stats_by_target_band_night(visits)
         self.assertEqual(night_teff.index.names[0], "target_name")
         self.assertEqual(night_teff.index.names[1], "day_obs_iso8601")
         for col_name in night_teff.columns:

--- a/tests/test_plot_cadence.py
+++ b/tests/test_plot_cadence.py
@@ -29,7 +29,7 @@ class TestPlotCadence(TestCase):
 
         visit_db_fname = get_baseline()
         visits = schedview.collect.read_ddf_visits(visit_db_fname, stackers=stackers)
-        night_totals = schedview.compute.visits.accum_teff_by_night(visits)
+        night_totals = schedview.compute.visits.accum_stats_by_target_band_night(visits)
         start_dayobs_mjd = np.floor(visits.observationStartMJD.min())
         end_dayobs_mjd = start_dayobs_mjd + 365
         plot = create_cadence_plot(night_totals, start_dayobs_mjd, end_dayobs_mjd)


### PR DESCRIPTION
To demonstrate the new code, you can use the example executable `schedview/examples/ddfcadence.py` in the `schedview` package. For example, in a conda environment with recent `rubin_scheduler`, `rubin_sim`, and `schedview` packages installed on a USDF devel node with `$SCHEDVIEW_DIR` pointing to the directory where schedview is installed, you can run the ddf example executable thus:

`python ${SCHEDVIEW_DIR}/schedview/examples/ddfcadence.py 2027-06-22 4.3 ddfcad43.html --nights 365`

and it will create the html file `ddfcad43.html` with the plot with the hovertext in it.

Alternately, the `scheduler_nightsum.ipynb` notebook in the tickets/SP-2228 branch of `schedview_notebooks` calls this new code to create its DDF cadence plot.