### PR TITLE
tickets/SP-2352: add code to build a table of contents for pre-generate schedview reports (plus rss, which is almost the same)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 25.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -16,12 +16,12 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.278
+    rev: v0.12.0
     hooks:
       - id: ruff

--- a/schedview/plot/overhead.py
+++ b/schedview/plot/overhead.py
@@ -1,6 +1,5 @@
 # Allow import of ElementTree as ET following the recommendation in the
 # official python docs.
-# ruff: noqa: N817
 
 from io import StringIO
 from xml.etree import ElementTree as ET

--- a/schedview/plot/survey_skyproj.py
+++ b/schedview/plot/survey_skyproj.py
@@ -218,7 +218,7 @@ def create_hpix_visit_map_grid(
     # Bands should be in wavelength order for standard bands, and the rest
     # should come after in alphabetical order.
     bands = [b for b in "ugrizy" if b in present_bands] + sorted(
-        b for b in "ugrizy" if b not in present_bands
+        b for b in present_bands if b not in "ugrizy"
     )
 
     for band_idx, band in enumerate(bands):

--- a/schedview/reports.py
+++ b/schedview/reports.py
@@ -1,0 +1,166 @@
+import datetime
+import email.utils
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pandas as pd
+
+
+def find_reports(
+    report_dir: str = " /sdf/data/rubin/shared/scheduler/reports",
+    url_base: str = "https://usdf-rsp-int.slac.stanford.edu/schedview-static-pages",
+) -> pd.DataFrame:
+    """Find staticic schedview reports by walking the report directory.
+
+    Parameters
+    ----------
+    report_dir : `str`
+        The root path of the directory with the reports
+    urs_base : `str`
+        The base of the that serves files in the report dir
+
+    Returns
+    -------
+    reports : `pandas.DataFrame`
+        A `pandas.DataFrame` with the following columns:
+
+        ``night``
+            The local calendar date of the night start (`datetime.date`).
+        ``dayobs``
+            The SITCOMTN-032 dayobs of the night (`int`).
+        ``report``
+            The report name (`str`).
+        ``instrument``
+            The instrument (`str`).
+        ``url``
+            The URL for the report (`str`).
+        ``report_time``
+            The file creation time for the report (`datetime.datetime`).
+        ``fname``
+            The filename of the report.
+    """
+
+    report_list = []
+    for dir_path, dir_names, file_names in os.walk(report_dir):
+        this_path = Path(dir_path)
+        for file_name in file_names:
+            if file_name.endswith(".html"):
+                file_path = str(this_path.joinpath(file_name))
+                relative_path = file_path[len(report_dir) + 1 :]
+                file_parts = relative_path.split("/")
+                if len(file_parts) == 6:
+                    report, instrument, year_str, month_str, day_str, _ = file_parts
+                    dayobs = year_str + month_str + day_str
+                    night_iso = "-".join([year_str, month_str, day_str])
+                    night_date = datetime.date.fromisoformat(night_iso)
+                    url = "/".join([url_base, relative_path])
+                    link = f'<a href="{url}" target="_blank" rel="noopener noreferrer">{report}</a>'
+                    mtime = datetime.datetime.fromtimestamp(
+                        Path(file_path).stat().st_mtime, datetime.UTC
+                    ).isoformat()
+                    report_list.append(
+                        pd.Series(
+                            dict(
+                                night=night_date,
+                                dayobs=dayobs,
+                                report=report,
+                                instrument=instrument,
+                                url=url,
+                                link=link,
+                                report_time=mtime,
+                                fname=file_name,
+                            )
+                        )
+                    )
+
+    reports = (
+        pd.DataFrame(report_list).set_index(["instrument", "dayobs"]).sort_values("night", ascending=False)
+    )
+
+    return reports
+
+
+def make_report_link_table(reports: pd.DataFrame) -> str:
+    """Generate an html table of links to reports.
+
+    Parameters
+    ----------
+    reports : `pd.DataFrame`
+        A DataFrame of report metadata, as returned by `find_reports`.
+
+    Returns
+    -------
+    report_table_html : `str`
+        The HTML formatted table with links.
+    """
+
+    report_links = (
+        reports.reset_index()
+        .pivot(index=("night", "instrument"), columns="report", values="link")
+        .sort_values("night", ascending=False)
+        .fillna("")
+        .reindex(columns=["prenight", "multiprenight", "nightsum", "compareprenight"])
+    )
+
+    report_table_html = report_links.to_html(escape=False)
+    return report_table_html
+
+
+def make_report_rss_feed(
+    reports: pd.DataFrame, fname: str | None = None, max_days: int = 7
+) -> ET.ElementTree:
+    """Generate an rss feed of recent schedview reports.
+
+    Parameters
+    ----------
+    reports : `pd.DataFrame`
+        A DataFrame of report metadata, as returned by `find_reports`.
+    fname : `str` or `None`
+        The file in which to write the RSS, if any. `None` to not write
+        a file at all. Defaults to `None`.
+    max_days : `int`
+        How many days worth of reports to include in the feed.
+
+    Returns
+    -------
+    rss : `ET.ElementTree`
+        The RSS XML itself.
+    """
+    rss = ET.Element("rss", attrib={"version": "2.0"})
+    channel = ET.SubElement(rss, "channel")
+    title = ET.SubElement(channel, "title")
+    title.text = "schedview reports"
+    desc = ET.SubElement(channel, "description")
+    desc.text = "Statically generated reports on Rubin Observatory/LSST scheduler status and progress"
+    for row_index, report_row in reports.iterrows():
+        if (datetime.date.today() - report_row.night).days > max_days:
+            # To make sure we keep the feed a reasonable size,
+            # don't include older stuff.
+            continue
+        instrument, dayobs = row_index
+        item = ET.SubElement(channel, "item")
+        title = ET.SubElement(item, "title")
+        title.text = f"{report_row.report} report for {instrument} on {report_row.night}"
+        # It's traditional to put a summary of the content in "description"
+        # and we could eventually have things like total numbers
+        # of visits in each band, stats on the seeing, etc. here.
+        # We can do this when our activities at night are no
+        # longer secret.
+        desc = ET.SubElement(item, "description")
+        desc.text = f"{report_row.report} report for {instrument} on {report_row.night}"
+        link = ET.SubElement(item, "link")
+        link.text = report_row.url
+        guid = ET.SubElement(item, "guid", attib={"isPermaLink": "false"})
+        guid.text = title.text + f", generated {report_row.report_time}"
+        category = ET.SubElement(item, "category")
+        category.text = f"{instrument}_{report_row.report}"
+        pubdate = ET.SubElement(item, "pubDate")
+        pubdate.text = email.utils.format_datetime(datetime.datetime.fromisoformat(report_row.report_time))
+    ET.indent(rss, space=".   ", level=0)
+
+    rss_tree = ET.ElementTree(rss)
+    if fname is not None:
+        rss_tree.write(fname)
+
+    return rss_tree

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,50 @@
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import schedview.reports
+
+
+class TestReports(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_report_fnames = []
+        cls.temp_dir = TemporaryDirectory()
+        year, month = "2025", "06"
+        cls.reports = ("prenight", "nightsum")
+        cls.instruments = ("lsstcam", "auxtel")
+        cls.days = ("20", "21")
+
+        for report in cls.reports:
+            for instrument in cls.instruments:
+                for day in cls.days:
+                    test_dir = Path(cls.temp_dir.name).joinpath(report, instrument, year, month, day)
+                    test_dir.mkdir(parents=True)
+                    test_file = test_dir.joinpath(f"{report}_{year}-{month}-{day}.html")
+                    cls.test_report_fnames.append(test_file)
+                    open(test_file, "a").close()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.temp_dir.cleanup()
+
+    def test_find_reports(self):
+        reports = schedview.reports.find_reports(self.temp_dir.name)
+        assert set(reports.columns) == {"report", "fname", "report_time", "night", "link", "url"}
+        assert len(reports) == len(self.test_report_fnames)
+
+    def test_make_report_link_table(self):
+        reports = schedview.reports.find_reports(self.temp_dir.name)
+        html_table = schedview.reports.make_report_link_table(reports)
+        # Make sure we can parse the result as XML
+        ET.fromstring(html_table)
+
+    def test_make_report_rss_feed(self):
+        reports = schedview.reports.find_reports(self.temp_dir.name)
+        test_file = Path(self.temp_dir.name).joinpath("test.rss")
+        rss_tree = schedview.reports.make_report_rss_feed(reports, str(test_file), 99999)
+        assert isinstance(rss_tree, ET.ElementTree)
+        # See if we can parse the result as XML
+        ET.parse(str(test_file))


### PR DESCRIPTION
The initial table of contents is in the schedview_notebooks notebook itself (in the PR for tickets/SP-2213), but it should be someplace reusable and testable, so here it is.

