### PR TITLE
SP-2370: Update required version of rubin_scheduler and rubin_sim

### DIFF
--- a/container_environment.yaml
+++ b/container_environment.yaml
@@ -8,7 +8,7 @@ dependencies:
  - numpy
  - pandas
  - astropy >= 5.3
- - uranography >= 1.1.0
+ - uranography >= 1.2.1
  - bokeh >= 3.1.1
  - panel >= 1.1.0
  - uranography
@@ -18,8 +18,8 @@ dependencies:
  - boto3
  - wget
  - lsst-efd-client
- - rubin-scheduler = 3.10.0
- - rubin-sim
+ - rubin-scheduler >= 3.10.0
+ - rubin-sim >= 2.2.4
  - scikit-learn
  - pip
  - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dependencies = [
     "pytz",
     "skyproj",
     "tabulate",
-    "rubin-scheduler",
-    "rubin-sim",
+    "rubin-scheduler >= 3.11.0",
+    "rubin-sim >= 2.2.4",
     "uranography >= 1.1.0 ",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astropy>=5.3
+astropy-base>=5.3
 bokeh>=3.1.1
 colorcet
 healpy
@@ -15,6 +15,6 @@ scikit-learn
 skyproj
 tabulate
 uranography>=1.1.0
-rubin-scheduler
-rubin-sim>=2
+rubin-scheduler>=3.11.0
+rubin-sim>=2.2.4
 pip

--- a/schedview/collect/visits.py
+++ b/schedview/collect/visits.py
@@ -1,4 +1,5 @@
 import re
+
 import pandas as pd
 from lsst.resources import ResourcePath
 from rubin_scheduler.utils import ddf_locations
@@ -86,7 +87,7 @@ def read_visits(
         if visit_source == "baseline":
             # Special case of the current baseline.
             opsim_rp = ResourcePath(get_baseline())
-        elif re.search(r'^(\d+\.)*\d+$', visit_source):
+        elif re.search(r"^(\d+\.)*\d+$", visit_source):
             # If the value was just a version # like 4.3.5 (or 4.3),
             # Map it into the appropriate file at USDF storage.
             opsim_rp = ResourcePath(OPSIMDB_TEMPLATE.format(sim_version=visit_source))


### PR DESCRIPTION
This updates the requirements.txt and the pyproject.toml to the minimum required versions of rubin-sim and rubin-scheduler.

I did a bad PR, but also added a slight modification to read_visits so that you can read not-just the baseline or a version # (but also, say, the sv survey simulation output). Eric and Lynne discussed this over the weekend.