### PR TITLE
tickets/SP-2443: add config_logging_for_reports

### DIFF
--- a/schedview/util.py
+++ b/schedview/util.py
@@ -1,3 +1,6 @@
+import logging
+import os
+
 BAND_COLUMN_NAME_CANDIDATES = ("band", "filter")
 
 
@@ -19,3 +22,46 @@ def band_column(visits):
             return band
 
     return BAND_COLUMN_NAME_CANDIDATES[0]
+
+
+def config_logging_for_reports(stream_level: int = logging.ERROR):
+    """Configure logging for a jupyter notebook that generates a report
+
+    Parameters
+    ----------
+    stream_level : `int`
+        Log level to actually be shown in the report.
+
+    Notes
+    -----
+    If the ``SCHEDVIEW_REPORT_LOG`` environment variable is set, send
+    log messages in to the file named by that variable.
+    """
+
+    # Get rid of any existing handlers of the root logger
+    # so we get only those we add here.
+    logging.getLogger().handlers.clear()
+
+    # Set the format.
+    log_formatter = logging.Formatter(
+        fmt="%(asctime)s %(levelname)s %(name)s: %(message)s", datefmt="%Y-%m-%dT%H:%M:%S"
+    )
+
+    log_filename = os.environ.get("SCHEDVIEW_REPORT_LOG", "")
+    if log_filename:
+        file_handler = logging.FileHandler(log_filename)
+        file_handler.setFormatter(log_formatter)
+        logging.getLogger().addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(log_formatter)
+    stream_handler.setLevel(stream_level)
+    logging.getLogger().addHandler(stream_handler)
+
+    # Send all warnings to the logger to be handled by our handlers.
+    logging.captureWarnings(True)
+    # If we want to configure captured warning log messages,
+    # separately from other log messages,
+    # get the relevant logger with logging.getLogger('py.warnings').
+    # By default, it's just propogated to the root logger,
+    # so is handled by the handler set above.


### PR DESCRIPTION
Example render of a schedview notebook that uses it: https://usdf-rsp-int.slac.stanford.edu/schedview-static-pages/nightsum/lsstcam/2025/07/14/nightsum_2025-07-14.html

The idea here is to redirect all warnings to the logger with level `logger.WARNING`, and by default in renders for users have the level be `logger.ERROR` so they don't show up. If log messages are at `logger.ERROR` or higher (`logger.CRITICAL`), then I expect the output of the notebook to be messed up or wrong, so I don't think it should be suppressed, even for users.

When developing, though, I suggest we leave it at `logger.WARNING` so we don't miss stuff or lose track of things we shouldn't.

