### PR TITLE
tickets/SP-3039: add functionaly to support reusable collapsable tables in schedview reports

### DIFF
--- a/schedview/collect/reportenv.py
+++ b/schedview/collect/reportenv.py
@@ -1,0 +1,19 @@
+import platform
+
+import pandas as pd
+import rubin_scheduler
+import rubin_sim
+
+from .. import __version__ as schedview_version
+
+
+def get_report_sw_versions():
+    report_sw_versions = pd.DataFrame(
+        columns=["package_version"],
+        index=pd.Index([], name="package_name"),
+    )
+    report_sw_versions.loc["python", "package_version"] = platform.python_version()
+    report_sw_versions.loc["rubin-scheduler", "package_version"] = rubin_scheduler.__version__
+    report_sw_versions.loc["rubin-sim", "package_version"] = rubin_sim.__version__
+    report_sw_versions.loc["schedview", "package_version"] = schedview_version
+    return report_sw_versions

--- a/schedview/plot/html.py
+++ b/schedview/plot/html.py
@@ -1,5 +1,18 @@
+"""Functions for converting data to HTML representations.
+
+This module provides utility functions for converting various data structures
+(such as pandas Series, DataFrames, and mappings) to HTML fragments for
+inclusion in reports, dashboards, and interactive notebook displays.
+
+The main conversion function `convert_to_html` handles multiple input types
+and can optionally wrap content in collapsible ``<details>`` elements.
+Additional convenience functions are provided for specific data types:
+simulation metadata, night events, sun and moon positions, overhead summaries,
+and survey visit summaries.
+"""
+
 from collections.abc import Mapping
-from typing import Any, List, Sequence
+from typing import Any, Sequence
 
 import matplotlib as mpl
 import numpy as np
@@ -17,7 +30,62 @@ def convert_to_html(
     collapsed: bool = True,
     heading_level: int = 3,
     pd_context_options: Sequence | None = None,
-):
+) -> str:
+    """Convert supported content objects into an HTML fragment.
+
+    This function accepts either pre-rendered HTML text or several supported
+    Python objects and converts them to HTML. The resulting HTML can be
+    returned directly, wrapped under a heading, or wrapped in a collapsible
+    ``<details>`` section.
+
+    Parameters
+    ----------
+    content : `str` or `pandas.Series` or `pandas.DataFrame` or
+        `matplotlib.figure.Figure` or `pandas.io.formats.style.Styler`
+        Content to convert to HTML.
+
+        - `str`: assumed to already be HTML content.
+        - `pandas.Series`: converted to a one-column table and styled with
+          left-aligned text.
+        - `pandas.DataFrame` or `pandas.io.formats.style.Styler`: rendered via
+          ``to_html`` under the configured pandas option context.
+        - `matplotlib.figure.Figure`: converted via
+          `schedview.plot.mpl_fig_to_html`.
+    title : `str`, optional
+        Title text to use in the section header or ``<summary>`` element.
+        Required when ``collapsed`` is `True`.
+    collapsed : `bool`, optional
+        If `True`, wrap content in ``<details>``/``<summary>``. If `False`,
+        return content directly when ``title`` is empty, or prepend an HTML
+        heading when ``title`` is provided.
+    heading_level : `int`, optional
+        Heading level to use for non-collapsed titled output. Must be one of
+        ``1`` through ``6``.
+    pd_context_options : sequence, optional
+        Positional arguments passed to `pandas.option_context` while rendering
+        `pandas.DataFrame` and `pandas.io.formats.style.Styler` inputs. If
+        `None`, `DEFAULT_PD_CONTEXT_OPTIONS` is used.
+
+    Returns
+    -------
+    result : `str`
+        HTML fragment containing the converted content and optional wrapper
+        markup.
+
+    Raises
+    ------
+    ValueError
+        Raised if ``collapsed`` is `True` and ``title`` is empty.
+    AssertionError
+        Raised if final argument validation fails (for example, unsupported
+        ``heading_level`` values).
+
+    Notes
+    -----
+    Pandas display options are applied only within a local
+    `pandas.option_context` block during DataFrame and Styler conversion.
+    Generated HTML is returned as-is and is not sanitized by this function.
+    """
     # If no pandas context options are specified, use the defaults
     if pd_context_options is None:
         pd_context_options = DEFAULT_PD_CONTEXT_OPTIONS
@@ -64,8 +132,8 @@ def convert_to_html(
 
 
 def markup_sim_index_info(
-    sim_index_info,
-    shown_values=(
+    sim_index_info: pd.Series,
+    shown_values: Sequence[str] = (
         "visitseq_uuid",
         "sim_creation_day_obs",
         "daily_id",
@@ -76,8 +144,38 @@ def markup_sim_index_info(
         "config_url",
         "tags",
     ),
-    collapsed=True,
-):
+    collapsed: bool = True,
+) -> str:
+    """Convert simulation index information to an HTML representation.
+
+    Parameters
+    ----------
+    sim_index_info : `pandas.Series`
+        Simulation index information as returned by
+        `rubin_sim.sim_archive.prenightindex.get_sim_index_info`.
+        Must contain at least the fields in ``shown_values``.
+    shown_values : sequence of `str`, optional
+        Field names to include in the HTML representation. Default is a
+        standard set of metadata fields including UUID, day observation,
+        visit sequence label, telescope, URLs, and tags.
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with the visit sequence label and telescope as the summary text.
+        If `False`, return the content without collapsible wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the simulation index information.
+
+    Notes
+    -----
+    The ``sim_index_info`` Series is expected to contain fields such as
+    ``visitseq_uuid``, ``sim_creation_day_obs``, ``daily_id``,
+    ``visitseq_label``, ``creation_time``, ``telescope``, ``visitseq_url``,
+    ``config_url``, and ``tags``. The ``visitseq_label`` and ``telescope``
+    fields are used to construct the summary title when ``collapsed=True``.
+    """
     content = (
         sim_index_info[list(shown_values)]
         .to_frame()
@@ -90,7 +188,34 @@ def markup_sim_index_info(
     return html_representation
 
 
-def markup_additional_sim_files(sim_index_info, collapsed=True):
+def markup_additional_sim_files(
+    sim_index_info: pd.Series,
+    collapsed: bool = True,
+) -> str:
+    """Convert simulation additional files information to an HTML representation.
+
+    Parameters
+    ----------
+    sim_index_info : `pandas.Series`
+        Simulation index information as returned by
+        `rubin_sim.sim_archive.prenightindex.get_sim_index_info`.
+        Must contain a ``files`` attribute mapping file names to URIs.
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with "Additional files available" as the summary text.
+        If `False`, return the content without collapsible wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the list of additional files with their URIs.
+
+    Notes
+    -----
+    The ``sim_index_info.files`` attribute is expected to be a dictionary-like
+    mapping where keys are file names (e.g., "rewards", "scheduler_pickle") and
+    values are URIs or paths to the files.
+    """
     content = (
         pd.Series(sim_index_info.files)
         .to_frame()
@@ -103,7 +228,36 @@ def markup_additional_sim_files(sim_index_info, collapsed=True):
     return html_representation
 
 
-def markup_sim_comments(sim_info, collapsed=True):
+def markup_sim_comments(
+    sim_info: pd.Series,
+    collapsed: bool = True,
+) -> str:
+    """Convert comments on a simulation to an HTML representation.
+
+    Parameters
+    ----------
+    sim_info : `pandas.Series`
+        Simulation index information as returned by
+        `rubin_sim.sim_archive.prenightindex.get_sim_index_info`.
+        Must contain a ``comments`` attribute mapping timestamps to comment
+        content strings.
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with "Comments recorded in the simulation metadata database" as the
+        summary text. If `False`, return the content without collapsible
+        wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the simulation comments with timestamps.
+
+    Notes
+    -----
+    The ``sim_info.comments`` attribute is expected to be a dictionary-like
+    mapping where keys are timestamp strings and values are comment content
+    strings.
+    """
     comment_content = ""
     for comment_time, comment_content in sim_info.comments.items():
         comment_content = comment_content + f"<h4>{comment_time}</h4><p>{comment_content}</p> "
@@ -114,7 +268,30 @@ def markup_sim_comments(sim_info, collapsed=True):
     return html_representation
 
 
-def markup_night_events(night_events, collapsed=True):
+def markup_night_events(
+    night_events: pd.DataFrame,
+    collapsed: bool = True,
+) -> str:
+    """Convert a DataFrame of night astronomical events to HTML.
+
+    Parameters
+    ----------
+    night_events : `pandas.DataFrame`
+        A DataFrame of night astronomical events as returned by
+        `schedview.compute.astro.night_events`. Must contain the following
+        index values: 'sunset', 'sunrise', 'sun_n12_setting', 'sun_n12_rising',
+        'night_middle'. Must contain the following columns: 'UTC'.
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with a summary showing the times of key astronomical events.
+        If `False`, return the content without collapsible wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the night events table, optionally wrapped in
+        a collapsible details/summary element.
+    """
     if collapsed:
         title = f"""
             Sunset: {night_events.loc['sunset', 'UTC'].isoformat()[11:19]}Z,
@@ -129,7 +306,41 @@ def markup_night_events(night_events, collapsed=True):
     return html_representation
 
 
-def markup_sun_moon_positions(sun_moon_positions, collapsed=True):
+def markup_sun_moon_positions(sun_moon_positions: Mapping[str, float], collapsed: bool = True) -> str:
+    """Convert sun and moon position data to an HTML representation.
+
+    Parameters
+    ----------
+    sun_moon_positions : `~collections.abc.Mapping` [`str`, `float`]
+        Sun and moon position data as returned by
+        ``ModelObservatory.almanac.get_sun_moon_positions(mjd)``.
+        Must contain the following keys for the sun: ``sun_RA``, ``sun_dec``,
+        ``sun_alt``, ``sun_az``.
+        Must contain the following keys for the moon: ``moon_RA``, ``moon_dec``,
+        ``moon_alt``, ``moon_az``, ``moon_phase``.
+        Values are angles in radians (except phase which is in percent).
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with a summary showing the approximate RA and dec of the sun and moon.
+        If `False`, return the content without collapsible wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the sun and moon positions table, optionally
+        wrapped in a collapsible details/summary element.
+
+    Notes
+    -----
+    The position data is converted from radians to degrees in the resulting
+    table. The table has two rows (sun and moon) and four columns (RA, dec,
+    alt, az) plus a phase column for the moon.
+
+    See Also
+    --------
+    schedview.compute.astro.compute_sun_moon_positions
+        A similar function that returns a DataFrame of sun and moon positions.
+    """
     body_positions_wide = pd.DataFrame(sun_moon_positions)
     body_positions_wide.index.name = "r"
     body_positions_wide.reset_index(inplace=True)
@@ -160,10 +371,55 @@ def markup_mapping_with_format(
     data: Mapping[str, Any],
     stat_name: Mapping[str, str],
     stat_str_template: Mapping[str, str],
-    summary_fields: List[str],
+    summary_fields: Sequence[str],
     title: str,
     collapsed: bool = True,
-):
+) -> str:
+    """Convert a mapping of formatted statistics to an HTML representation.
+
+    This function formats values from a data mapping using string templates,
+    creates a DataFrame with the formatted values, and returns an HTML
+    representation that can be wrapped in collapsible elements.
+
+    Parameters
+    ----------
+    data : `~collections.abc.Mapping` [`str`, `Any`]
+        Mapping of statistic keys to their values. These values will be
+        formatted using the provided templates.
+    stat_name : `~collections.abc.Mapping` [`str`, `str`]
+        Mapping of statistic keys to display names used as the index in
+        the resulting HTML table.
+    stat_str_template : `~collections.abc.Mapping` [`str`, `str`]
+        Mapping of statistic keys to Python string format templates.
+        Each template should contain a single format specifier (e.g., ``"{}"``,
+        ``"{:5.2f}"``) that will be filled with the corresponding data value.
+    summary_fields : sequence of `str`
+        List of statistic keys to include in the summary text when
+        ``collapsed=True``. These must match keys in ``stat_name``.
+    title : `str`
+        Base title for the HTML representation. When ``collapsed=True``,
+        this is overridden by a summary built from ``summary_fields``.
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with a summary built from ``summary_fields``. If `False`, return
+        the content without collapsible wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the formatted statistics table, optionally
+        wrapped in a collapsible details/summary element.
+
+    Notes
+    -----
+    The function processes each key in ``data`` by:
+    1. Looking up the display name in ``stat_name``
+    2. Formatting the value using ``stat_str_template``
+    3. Creating a DataFrame with these formatted values
+
+    This function is typically called indirectly via wrapper functions such as
+    `markup_overhead_summary` and `markup_survey_visit_summary`.
+    """
     index_values = [stat_name[k] for k in data]
     value_str = [stat_str_template[k].format(data[k]) for k in data]
     content = pd.DataFrame({"value": value_str}, index=index_values)
@@ -174,7 +430,27 @@ def markup_mapping_with_format(
     return html_representation
 
 
-def markup_overhead_summary(overhead_summary, collapsed=True):
+def markup_overhead_summary(overhead_summary: Mapping[str, Any], collapsed: bool = True) -> str:
+    """Convert overhead summary statistics to an HTML representation.
+
+    Parameters
+    ----------
+    overhead_summary : `~collections.abc.Mapping` [`str`, `Any`]
+        Mapping of overhead statistic keys to their values. Expected keys are
+        ``relative_start_time``, ``relative_end_time``, ``total_time``,
+        ``num_exposures``, ``total_exptime``, ``mean_gap_time``,
+        ``median_gap_time``.
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with a summary built from key statistics. If `False`, return the
+        content without collapsible wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the overhead summary statistics table,
+        optionally wrapped in a collapsible details/summary element.
+    """
     stat_name = {
         "relative_start_time": "Open shutter of first exposure",
         "relative_end_time": "Close shutter of last exposure",
@@ -201,7 +477,26 @@ def markup_overhead_summary(overhead_summary, collapsed=True):
     return html_representation
 
 
-def markup_survey_visit_summary(survey_visit_summary, collapsed=True):
+def markup_survey_visit_summary(survey_visit_summary: Mapping[str, Any], collapsed: bool = True) -> str:
+    """Convert survey visit summary statistics to an HTML representation.
+
+    Parameters
+    ----------
+    survey_visit_summary : `~collections.abc.Mapping` [`str`, `Any`]
+        Mapping of survey visit statistic keys to their values. Expected keys
+        are ``n12_night_time``, ``n_survey_visits``, ``n_pairs_started``,
+        ``n_pairs_finished``, ``ddfs_observed``, ``too_observed``.
+    collapsed : `bool`, optional
+        If `True`, wrap the output in a ``<details>``/``<summary>`` element
+        with a summary built from key statistics. If `False`, return the
+        content without collapsible wrapping.
+
+    Returns
+    -------
+    html_representation : `str`
+        HTML string containing the survey visit summary statistics table,
+        optionally wrapped in a collapsible details/summary element.
+    """
     stat_name = {
         "n12_night_time": "Time between 12 degree evening and morning twilights",
         "n_survey_visits": "Number of survey visits in night",

--- a/schedview/plot/html.py
+++ b/schedview/plot/html.py
@@ -259,8 +259,8 @@ def markup_sim_comments(
     strings.
     """
     comment_content = ""
-    for comment_time, comment_content in sim_info.comments.items():
-        comment_content = comment_content + f"<h4>{comment_time}</h4><p>{comment_content}</p> "
+    for comment_time, this_comment_content in sim_info.comments.items():
+        comment_content = comment_content + f"<h4>{comment_time}</h4><p>{this_comment_content}</p> "
 
     html_representation = convert_to_html(
         comment_content, "Comments recorded in the simulation metadata database", collapsed=collapsed
@@ -306,7 +306,9 @@ def markup_night_events(
     return html_representation
 
 
-def markup_sun_moon_positions(sun_moon_positions: Mapping[str, float], collapsed: bool = True) -> str:
+def markup_sun_moon_positions(
+    sun_moon_positions: Mapping[str, float | np.ndarray], collapsed: bool = True
+) -> str:
     """Convert sun and moon position data to an HTML representation.
 
     Parameters
@@ -341,7 +343,11 @@ def markup_sun_moon_positions(sun_moon_positions: Mapping[str, float], collapsed
     schedview.compute.astro.compute_sun_moon_positions
         A similar function that returns a DataFrame of sun and moon positions.
     """
-    body_positions_wide = pd.DataFrame(sun_moon_positions)
+    # We might get a mapping of single value numpy arrays.
+    # If we do, convert them to scalars.
+    sun_moon_positions = {k: float(v if np.isscalar(v) else v.item()) for k, v in sun_moon_positions.items()}
+
+    body_positions_wide = pd.Series(sun_moon_positions).to_frame().T
     body_positions_wide.index.name = "r"
     body_positions_wide.reset_index(inplace=True)
 

--- a/schedview/plot/html.py
+++ b/schedview/plot/html.py
@@ -1,4 +1,5 @@
-from typing import Sequence
+from collections.abc import Mapping
+from typing import Any, List, Sequence
 
 import matplotlib as mpl
 import numpy as np
@@ -155,6 +156,24 @@ def markup_sun_moon_positions(sun_moon_positions, collapsed=True):
     return html_representation
 
 
+def markup_mapping_with_format(
+    data: Mapping[str, Any],
+    stat_name: Mapping[str, str],
+    stat_str_template: Mapping[str, str],
+    summary_fields: List[str],
+    title: str,
+    collapsed: bool = True,
+):
+    index_values = [stat_name[k] for k in data]
+    value_str = [stat_str_template[k].format(data[k]) for k in data]
+    content = pd.DataFrame({"value": value_str}, index=index_values)
+    if collapsed:
+        title = ", ".join([f"{f}: {content.loc[f, 'value']}" for f in summary_fields])
+
+    html_representation = convert_to_html(content.to_html(header=False), title, collapsed=collapsed)
+    return html_representation
+
+
 def markup_overhead_summary(overhead_summary, collapsed=True):
     stat_name = {
         "relative_start_time": "Open shutter of first exposure",
@@ -174,14 +193,34 @@ def markup_overhead_summary(overhead_summary, collapsed=True):
         "mean_gap_time": "{:7.2f} seconds",
         "median_gap_time": "{:7.2f} seconds",
     }
-    index_values = [stat_name[k] for k in overhead_summary]
-    value_str = [stat_str_template[k].format(overhead_summary[k]) for k in overhead_summary]
-    content = pd.DataFrame({"value": value_str}, index=index_values)
-    if collapsed:
-        summary_fields = ["Number of exposures", "Mean gap time", "Median gap time"]
-        title = ", ".join([f"{f}: {content.loc[f, 'value']}" for f in summary_fields])
-    else:
-        title = "Time on sky"
+    title = "Time on sky"
+    summary_fields = ["Number of exposures", "Mean gap time", "Median gap time"]
+    html_representation = markup_mapping_with_format(
+        overhead_summary, stat_name, stat_str_template, summary_fields, title, collapsed=collapsed
+    )
+    return html_representation
 
-    html_representation = convert_to_html(content.to_html(header=False), title, collapsed=collapsed)
+
+def markup_survey_visit_summary(survey_visit_summary, collapsed=True):
+    stat_name = {
+        "n12_night_time": "Time between 12 degree evening and morning twilights",
+        "n_survey_visits": "Number of survey visits in night",
+        "n_pairs_started": "Number of pairs started",
+        "n_pairs_finished": "Number of pairs finished",
+        "ddfs_observed": "DDFs Observed",
+        "too_observed": "ToOs Observed",
+    }
+    stat_str_template = {
+        "n12_night_time": "{:5.2f} hours",
+        "n_survey_visits": "{}",
+        "n_pairs_started": "{}",
+        "n_pairs_finished": "{}",
+        "ddfs_observed": "{}",
+        "too_observed": "{}",
+    }
+    title = "Survey visit counts"
+    summary_fields = ["Number of survey visits in night", "DDFs Observed", "ToOs Observed"]
+    html_representation = markup_mapping_with_format(
+        survey_visit_summary, stat_name, stat_str_template, summary_fields, title, collapsed=collapsed
+    )
     return html_representation

--- a/schedview/plot/html.py
+++ b/schedview/plot/html.py
@@ -1,0 +1,187 @@
+from typing import Sequence
+
+import matplotlib as mpl
+import numpy as np
+import pandas as pd
+import pandas.io.formats.style
+
+from . import mpl_fig_to_html
+
+DEFAULT_PD_CONTEXT_OPTIONS = ("display.width", 300, "display.max_colwidth", None)
+
+
+def convert_to_html(
+    content: str | pd.Series | pd.DataFrame | mpl.figure.Figure | pd.io.formats.style.Styler,
+    title: str = "",
+    collapsed: bool = True,
+    heading_level: int = 3,
+    pd_context_options: Sequence | None = None,
+):
+    # If no pandas context options are specified, use the defaults
+    if pd_context_options is None:
+        pd_context_options = DEFAULT_PD_CONTEXT_OPTIONS
+
+    pd_context_options = list(pd_context_options)
+
+    # Convert recognized non-HTML to HTML
+    if isinstance(content, pd.Series):
+        content = content.to_frame().style.hide(axis="columns").set_properties(**{"text-align": "left"})
+
+    if isinstance(content, pd.DataFrame) or isinstance(content, pd.io.formats.style.Styler):
+        with pd.option_context(*pd_context_options):
+            content = content.to_html()
+
+    if isinstance(content, mpl.figure.Figure):
+        content = mpl_fig_to_html(content)
+
+    # After processing our arguments, make sure all the types are as expected.
+    assert isinstance(content, str), f"content not a string, was {type(content)}"
+    assert isinstance(pd_context_options, list), "context options not a list"
+    assert heading_level in (1, 2, 3, 4, 5, 6), "heading level invalid"
+
+    result: str
+    if collapsed:
+        if len(title) < 1:
+            raise ValueError("If a section is collapsed, it must have a title")
+        result = f"""
+            <details>
+            <summary><b>{title}</b>
+            </summary>
+            {content}
+            </details>
+        """
+    else:
+        if len(title) < 1:
+            result = content
+        else:
+            result = f"""
+                <h{heading_level}>{title}</h{heading_level}>
+                {content}
+            """
+
+    return result
+
+
+def markup_sim_index_info(
+    sim_index_info,
+    shown_values=(
+        "visitseq_uuid",
+        "sim_creation_day_obs",
+        "daily_id",
+        "visitseq_label",
+        "creation_time",
+        "telescope",
+        "visitseq_url",
+        "config_url",
+        "tags",
+    ),
+    collapsed=True,
+):
+    content = (
+        sim_index_info[list(shown_values)]
+        .to_frame()
+        .style.hide(axis="columns")
+        .set_properties(**{"text-align": "left"})
+        .to_html()
+    )
+    title = f"{sim_index_info['visitseq_label']} ({sim_index_info['telescope']})"
+    html_representation = convert_to_html(content, title, collapsed=collapsed)
+    return html_representation
+
+
+def markup_additional_sim_files(sim_index_info, collapsed=True):
+    content = (
+        pd.Series(sim_index_info.files)
+        .to_frame()
+        .rename(columns={0: "URI"})
+        .style.set_properties(**{"text-align": "left"})
+        .to_html()
+    )
+    title = "Additional files available"
+    html_representation = convert_to_html(content, title, collapsed=collapsed)
+    return html_representation
+
+
+def markup_sim_comments(sim_info, collapsed=True):
+    comment_content = ""
+    for comment_time, comment_content in sim_info.comments.items():
+        comment_content = comment_content + f"<h4>{comment_time}</h4><p>{comment_content}</p> "
+
+    html_representation = convert_to_html(
+        comment_content, "Comments recorded in the simulation metadata database", collapsed=collapsed
+    )
+    return html_representation
+
+
+def markup_night_events(night_events, collapsed=True):
+    if collapsed:
+        title = f"""
+            Sunset: {night_events.loc['sunset', 'UTC'].isoformat()[11:19]}Z,
+            evening 12&#176: {night_events.loc['sun_n12_setting', 'UTC'].isoformat()[11:19]}Z,
+            morning 12&#176;: {night_events.loc['sun_n12_rising', 'UTC'].isoformat()[11:19]}Z,
+            Sunrise: {night_events.loc['sunrise', 'UTC'].isoformat()[11:19]}Z
+        """
+    else:
+        title = "Night events"
+
+    html_representation = convert_to_html(night_events, title, collapsed=collapsed)
+    return html_representation
+
+
+def markup_sun_moon_positions(sun_moon_positions, collapsed=True):
+    body_positions_wide = pd.DataFrame(sun_moon_positions)
+    body_positions_wide.index.name = "r"
+    body_positions_wide.reset_index(inplace=True)
+
+    angle_columns = ["RA", "dec", "alt", "az"]
+    all_columns = angle_columns + ["phase"]
+    body_positions = (
+        pd.wide_to_long(body_positions_wide, stubnames=("sun", "moon"), suffix=r".*", sep="_", i="r", j="")
+        .droplevel("r")
+        .T[all_columns]
+    )
+    body_positions[angle_columns] = np.degrees(body_positions[angle_columns])
+    if collapsed:
+        title = f"""
+            Sun &alpha;={body_positions.loc['sun','RA'].round()}&#176,
+            &delta;={body_positions.loc['sun','dec'].round()}&#176;
+            Moon &alpha;={body_positions.loc['moon','RA'].round()}&#176,
+            &delta;={body_positions.loc['moon','dec'].round()}&#176;
+        """
+    else:
+        title = "Sun and moon"
+
+    html_representation = convert_to_html(body_positions, title, collapsed=collapsed)
+    return html_representation
+
+
+def markup_overhead_summary(overhead_summary, collapsed=True):
+    stat_name = {
+        "relative_start_time": "Open shutter of first exposure",
+        "relative_end_time": "Close shutter of last exposure",
+        "total_time": "Total wall clock time",
+        "num_exposures": "Number of exposures",
+        "total_exptime": "Total open shutter time",
+        "mean_gap_time": "Mean gap time",
+        "median_gap_time": "Median gap time",
+    }
+    stat_str_template = {
+        "relative_start_time": "{:5.2f} minutes after 12 degree evening twilight",
+        "relative_end_time": "{:5.2f} minutes before 12 degree morning twilight",
+        "total_time": "{:4.2f} hours",
+        "num_exposures": "{}",
+        "total_exptime": "{:4.2f} hours",
+        "mean_gap_time": "{:7.2f} seconds",
+        "median_gap_time": "{:7.2f} seconds",
+    }
+    index_values = [stat_name[k] for k in overhead_summary]
+    value_str = [stat_str_template[k].format(overhead_summary[k]) for k in overhead_summary]
+    content = pd.DataFrame({"value": value_str}, index=index_values)
+    if collapsed:
+        summary_fields = ["Number of exposures", "Mean gap time", "Median gap time"]
+        title = ", ".join([f"{f}: {content.loc[f, 'value']}" for f in summary_fields])
+    else:
+        title = "Time on sky"
+
+    html_representation = convert_to_html(content.to_html(header=False), title, collapsed=collapsed)
+    return html_representation

--- a/schedview/plot/html.py
+++ b/schedview/plot/html.py
@@ -192,7 +192,7 @@ def markup_additional_sim_files(
     sim_index_info: pd.Series,
     collapsed: bool = True,
 ) -> str:
-    """Convert simulation additional files information to an HTML representation.
+    """Show simulation additional files information to as HTML.
 
     Parameters
     ----------
@@ -318,7 +318,8 @@ def markup_sun_moon_positions(
         ``ModelObservatory.almanac.get_sun_moon_positions(mjd)``.
         Must contain the following keys for the sun: ``sun_RA``, ``sun_dec``,
         ``sun_alt``, ``sun_az``.
-        Must contain the following keys for the moon: ``moon_RA``, ``moon_dec``,
+        Must contain the following keys for the moon: ``moon_RA``,
+        ``moon_dec``,
         ``moon_alt``, ``moon_az``, ``moon_phase``.
         Values are angles in radians (except phase which is in percent).
     collapsed : `bool`, optional

--- a/schedview/plot/overhead.py
+++ b/schedview/plot/overhead.py
@@ -1,6 +1,7 @@
 # Allow import of ElementTree as ET following the recommendation in the
 # official python docs.
 
+import warnings
 from io import StringIO
 from xml.etree import ElementTree as ET
 
@@ -65,6 +66,13 @@ def create_survey_visit_summary_table(sv_summary, html=True):
         Formatted summary.
     """
 
+    warnings.warn(
+        "create_survey_visit_summary_table() is deprecated, "
+        "use schedview.plot.html.markup_survey_visit_summary instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     stat_name = {
         "n12_night_time": "Time between 12 degree evening and morning twilights",
         "n_survey_visits": "Number of survey visits in night",
@@ -103,6 +111,13 @@ def create_overhead_summary_table(overhead_summary, html=True):
     `summary` : `str`
         Formatted summary.
     """
+    warnings.warn(
+        "create_overhead_summary_table() is deprecated, "
+        "use schedview.plot.html.markup_overhead_summary instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     stat_name = {
         "relative_start_time": "Open shutter of first exposure",
         "relative_end_time": "Close shutter of last exposure",

--- a/schedview/plot/visit_skymaps.py
+++ b/schedview/plot/visit_skymaps.py
@@ -53,6 +53,71 @@ DEFAULT_VISIT_PATCHES_KWARGS = {"name": "visit_patches", "line_alpha": 0.0}
 
 SPHEREMAP_FIGURE_KWARGS = {"match_aspect": True}
 
+NIGHTSUM_CAPTION = """<p>The above plots show the visits collected during the
+night in two different representations, modeled after physical
+observing tools.</p>
+<ul>
+<li>The map on the left shows the sphere in orthographic projection, with the
+   center point of the projection controlled by the "center alt" and
+   "center az" sliders beneath the plot. A static orthogrophic projection
+   is not an equal-area projection, but playing with the sliders is a helpful
+   way to inform a human's spatial
+   reasoning in three dimensions. Use of this map resembles use of an
+   <a href="https://en.wikipedia.org/wiki/Armillary_sphere">armillare
+   sphere</a>.</li>
+<li>The map on the right shows the sky in
+<a href="https://en.wikipedia.org/wiki/Lambert_azimuthal_equal-area_projection">Lambert Azimuthal Equal Area
+   Projection</a>,
+   centered at the south celestial pole, with R.A. increasing counterclockwise
+   (because Rubin Observatory is in the southern hemisphere). The projection
+   used is equal area, but highly distorted near the north celestial pole
+   (outside the LSST footprint). This is a
+   particularly helpful representation for planning observing, because changes
+   in time in relevant features
+   are simple rotations, without alterations in distortion, and there are no
+   discontinuities anywhere in the
+   footprint at any time of year. Use of this map resembles use of a
+   <a href="https://en.wikipedia.org/wiki/Planisphere">planisphere</a>.</li>
+</ul>
+<p>Both plots show the footprints of camera pointing taken up to the time set
+by the MJD slider, with the most
+recent three pointings outlined in cyan. The fill colors are:</p>
+<ul>
+<li><span style='background-color:{u}'>&nbsp;&nbsp;&nbsp;</span>
+    <span style='color:{u}'> aqua</span>: u band</li>
+<li><span style='background-color:{g}'>&nbsp;&nbsp;&nbsp;</span>
+    <span style='color:{g}'> green</span>: g band</li>
+<li><span style='background-color:{r}'>&nbsp;&nbsp;&nbsp;</span>
+    <span style='color:{r}'> red</span>: r band</li>
+<li><span style='background-color:{i}'>&nbsp;&nbsp;&nbsp;</span>
+    <span style='color:{i}'> blue</span>:
+   i band</li>
+<li><span style='background-color:{z}'>&nbsp;&nbsp;&nbsp;</span>
+    <span style='color:{z}'> purple</span>: z band</li>
+<li><span style='background-color:{y}'>&nbsp;&nbsp;&nbsp;</span>
+    <span style='color:{y}'> black</span>: y band</li>
+</ul>
+<p>Both plots have the following additional annotations:</p>
+<ul>
+<li>The gray background shows the planned final depth of the LSST survey.</li>
+<li>The orange disk shows the coordinates of the moon.</li>
+<li>The yellow disk shows the coordinates of the sun.</li>
+<li>The green line (oval) shows the ecliptic.</li>
+<li>The sun moves along the ecliptic in the direction of increasing R.A.
+    (counter-clockwise in the planisphere figure) such that it makes a full
+    revolution in one year.</li>
+<li>The moon moves roughly (within 5.14%deg;) along the ecliptic in the
+direction of increasing R.A. (counter-clockwise in the planisphere figure),
+completing a full revolution in one
+<a href="https://en.wikipedia.org/wiki/Lunar_month#Sidereal_month">sidereal
+month</a> (a bit over 27 days), about 14%deg; per day.</li>
+<li>The blue line (oval) shows the plane of the Milky Way.</li>
+<li>The black line shows the horizon at the time set by the MJD slider.</li>
+<li>The red line shows a zenith distince of 70%deg; (airmass=2.9) at the time
+set by the MJD slider.</li>
+</ul>
+"""
+
 
 class VisitMapBuilder:
     """Builder for interactive visit sky‑maps.
@@ -1557,3 +1622,66 @@ class VisitMapBuilder:
         assert isinstance(combined_figure, UIElement)
 
         return combined_figure
+
+    @classmethod
+    def nightsum(cls, visits=None, footprint_regions=None, alt_visits=None, mjd=None):
+        if mjd is None:
+            if visits is not None:
+                mjd = visits["observationStartMJD"].max()
+            elif alt_visits is not None:
+                mjd = alt_visits["observationStartMJD"].max()
+            else:
+                raise ValueError("If no visits are provided, mjd must not be None")
+
+        mjd_kwargs = {}
+        if visits is not None:
+            mjd_start = visits["observationStartMJD"].min()
+            mjd_end = visits["observationStartMJD"].max()
+            if alt_visits is not None:
+                mjd_start = min(mjd_start, alt_visits["observationStartMJD"].min())
+                mjd_end = min(mjd_end, alt_visits["observationStartMJD"].max())
+            mjd_kwargs = {"start": mjd_start, "end": mjd_end}
+        elif alt_visits is not None:
+            mjd_start = alt_visits["observationStartMJD"].min()
+            mjd_end = alt_visits["observationStartMJD"].max()
+            mjd_kwargs = {"start": mjd_start, "end": mjd_end}
+
+        builder = cls(
+            visits, mjd=mjd, map_classes=[ArmillarySphere, Planisphere], mjd_slider_kwargs=mjd_kwargs
+        )
+        builder.add_visit_patches()
+
+        if alt_visits is not None:
+            builder.add_alt_visit_patches(alt_visits)
+            visit_set_labels = (
+                alt_visits.loc[:, ["sim_index", "label"]].groupby("sim_index").first().to_dict()["label"]
+            )
+            if len(visit_set_labels) > 1:
+                builder.add_alt_visits_selector()
+
+        if footprint_regions is not None:
+            builder.add_footprint_outlines(footprint_regions)
+
+        builder = (
+            builder.add_eq_sliders()
+            .add_ecliptic()
+            .add_galactic_plane()
+            .add_datetime_slider()
+            .hide_mjd_slider()
+            .add_graticules()
+            .highlight_recent_visits()
+            .add_body("sun", size=15, color="yellow", alpha=1.0)
+            .add_body("moon", size=15, color="orange", alpha=0.8)
+            .add_horizon()
+            .add_horizon(zd=70, color="red")
+            .add_hovertext()
+            .add_play_controls()
+            .add_zenith_button()
+            .add_coord_sys_selector()
+        )
+
+        if visits is not None:
+            builder.hide_future_visits()
+
+        caption = NIGHTSUM_CAPTION.format(**builder.visit_fill_colors)
+        return builder, caption

--- a/schedview/plot/visit_skymaps.py
+++ b/schedview/plot/visit_skymaps.py
@@ -1492,6 +1492,8 @@ class VisitMapBuilder:
         )
 
         column_contents = [map_row, time_row, button_row]
+        if "alt_visits_selector" in self.ref_map.controls:
+            column_contents.insert(0, self.ref_map.controls["alt_visits_selector"])
 
         for control_key in ["ra", "decl", "alt", "az"]:
             column_contents.append(self.ref_map.controls[control_key])

--- a/schedview/plot/visit_skymaps.py
+++ b/schedview/plot/visit_skymaps.py
@@ -1624,7 +1624,46 @@ class VisitMapBuilder:
         return combined_figure
 
     @classmethod
-    def nightsum(cls, visits=None, footprint_regions=None, alt_visits=None, mjd=None):
+    def nightsum(
+        cls,
+        visits: Optional[pd.DataFrame] = None,
+        footprint_regions: Optional[np.ndarray] = None,
+        alt_visits: Optional[pd.DataFrame] = None,
+        mjd: Optional[float] = None,
+    ) -> Tuple["VisitMapBuilder", str]:
+        """Create a night summary visit sky-map visualization.
+
+        This class method creates a pre-configured `VisitMapBuilder` instance
+        optimized for the night summary reportr.
+
+        Parameters
+        ----------
+        visits : `pandas.DataFrame`, optional
+            Table of completed visits for the night. Must contain the required
+            columns: ``fieldRA``, ``fieldDec``, ``observationStartMJD``,
+            ``band``, ``rotSkyPos``. If None, only ``alt_visits`` can be used.
+        footprint_regions : `numpy.ndarray`, optional
+            Definitions of footprint regions.
+        alt_visits : `pandas.DataFrame`, optional
+            Table of alternative visit sets (e.g., from simulated schedulers)
+            to compare against completed visits. Must contain the same columns
+            as ``visits`` plus a ``sim_index`` column identifying the source
+            simulation. If provided with multiple simulations, a selector
+            widget will be added to switch between them.
+        mjd : `float`, optional
+            Reference Modified Julian Date for the visualization. If None,
+            the maximum ``observationStartMJD`` from ``visits`` or
+            ``alt_visits`` is used.
+
+        Returns
+        -------
+        builder : `VisitMapBuilder`
+            A fully configured `VisitMapBuilder` instance with visit patches,
+            decorations, and controls added.
+        caption : `str`
+            HTML-formatted caption describing the visualization elements,
+            including the meanings of colors and annotations.
+        """
         if mjd is None:
             if visits is not None:
                 mjd = visits["observationStartMJD"].max()

--- a/schedview/plot/visits.py
+++ b/schedview/plot/visits.py
@@ -133,6 +133,7 @@ def plot_visit_param_vs_time(
     num_plots: int = 1,
     user_figure_kwargs: dict | None = None,
     default_sim: str = "All",
+    sim_alpha: float = 0.2,
     **kwargs,
 ) -> bokeh.models.ui.ui_element.UIElement:
     """Plot a column in the visit table vs. time.
@@ -161,6 +162,8 @@ def plot_visit_param_vs_time(
         Arguments passed along to bokeh.plotting.figure
     default_sim: str
         Label of default sim to show (defaults to ``All``)
+    sim_alpha: float
+        The alpha of points for visible simulations.
     **kwargs
         Additional keyword arguments to be passed to
         `bokeh.plotting.figure.scatter`.
@@ -170,6 +173,8 @@ def plot_visit_param_vs_time(
     `plot` : `bokeh.models.plots.Plot`
         The figure with the plot.
     """
+    assert 0.0 <= sim_alpha <= 1.0, "sim_alpha must be between 0 and 1"
+
     # If there are no visits, do not make the plot.
     if len(visits) == 0:
         if plot is None:
@@ -211,10 +216,12 @@ def plot_visit_param_vs_time(
 
     if "sim_alpha" not in source.data:
         if default_sim == "All":
-            source.data["sim_alpha"] = np.full_like(source.data["start_timestamp"], 0.2, dtype=np.float64)
+            source.data["sim_alpha"] = np.full_like(
+                source.data["start_timestamp"], sim_alpha, dtype=np.float64
+            )
         else:
             source.data["sim_alpha"] = np.full_like(source.data["start_timestamp"], 0.0, dtype=np.float64)
-            source.data["sim_alpha"][source.data["label"] == default_sim] = 0.2
+            source.data["sim_alpha"][source.data["label"] == default_sim] = sim_alpha
 
         source.data["sim_alpha"][source.data["label"] == "Completed"] = 1.0
 
@@ -379,7 +386,9 @@ def plot_visit_param_vs_time(
                     if (source.data['label'][i] === 'Completed') {
                         source.data['sim_alpha'][i] = 1.0;
                     } else if (['All', source.data['label'][i]].includes(this.value)) {
-                        source.data['sim_alpha'][i] = 0.2;
+                        source.data['sim_alpha'][i] = """
+            + str(float(sim_alpha))
+            + """;
                     } else {
                         source.data['sim_alpha'][i] = 0.0;
                     }

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,14 +1,10 @@
-import datetime
+import re
 import unittest
-from collections import namedtuple
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
-from astropy.time import Time
 
 import schedview
-import schedview.compute.astro
 import schedview.plot.html
 
 
@@ -129,6 +125,122 @@ class TestConvertToHtml(unittest.TestCase):
             df, pd_context_options=("display.width", 200), collapsed=False
         )
         self.assertIn("col1", result)
+
+
+class TestMarkupMappingWithFormat(unittest.TestCase):
+    """Tests for markup_mapping_with_format function."""
+
+    def setUp(self):
+        """Create test data matching real usage patterns."""
+        # Overhead summary data matching compute_overhead_summary output
+        self.overhead_summary = {
+            "relative_start_time": 15.5,
+            "relative_end_time": 25.3,
+            "total_time": 8.5,
+            "num_exposures": 42,
+            "total_exptime": 5.25,
+            "mean_gap_time": 45.7,
+            "median_gap_time": 42.3,
+        }
+
+        # Stat name mapping (keys -> display names)
+        self.overhead_stat_name = {
+            "relative_start_time": "Open shutter of first exposure",
+            "relative_end_time": "Close shutter of last exposure",
+            "total_time": "Total wall clock time",
+            "num_exposures": "Number of exposures",
+            "total_exptime": "Total open shutter time",
+            "mean_gap_time": "Mean gap time",
+            "median_gap_time": "Median gap time",
+        }
+
+        # Stat string templates (format strings)
+        self.overhead_stat_str_template = {
+            "relative_start_time": "{:5.2f} minutes after 12 degree evening twilight",
+            "relative_end_time": "{:5.2f} minutes before 12 degree morning twilight",
+            "total_time": "{:4.2f} hours",
+            "num_exposures": "{}",
+            "total_exptime": "{:4.2f} hours",
+            "mean_gap_time": "{:7.2f} seconds",
+            "median_gap_time": "{:7.2f} seconds",
+        }
+
+    def test_collapsed_false_basic(self):
+        """Test basic functionality with collapsed=False."""
+        result = schedview.plot.html.markup_mapping_with_format(
+            self.overhead_summary,
+            self.overhead_stat_name,
+            self.overhead_stat_str_template,
+            ["Number of exposures"],
+            "Time on sky",
+            collapsed=False,
+        )
+        # Should contain formatted values
+        self.assertIn("15.50", result)
+        self.assertIn("42", result)
+        # Should not contain details/summary wrapper
+        self.assertNotIn("<details>", result)
+        self.assertNotIn("<summary>", result)
+
+    def test_summary_fields_appear_in_collapsed_summary(self):
+        """Test that summary fields appear in the collapsed summary text."""
+        summary_fields = ["Number of exposures", "Mean gap time", "Median gap time"]
+        result = schedview.plot.html.markup_mapping_with_format(
+            self.overhead_summary,
+            self.overhead_stat_name,
+            self.overhead_stat_str_template,
+            summary_fields,
+            "Time on sky",
+            collapsed=True,
+        )
+        # Summary fields should be formatted and appear in the summary.
+        self.assertTrue(re.search(r"Number of exposures:\s*42", result))
+        self.assertTrue(re.search(r"Mean gap time:\s*45\.70 seconds", result))
+        self.assertTrue(re.search(r"Median gap time:\s*42\.30 seconds", result))
+
+    def test_format_templates_applied_correctly(self):
+        """Test that format templates are applied correctly."""
+        result = schedview.plot.html.markup_mapping_with_format(
+            self.overhead_summary,
+            self.overhead_stat_name,
+            self.overhead_stat_str_template,
+            ["total_exptime"],
+            "Test",
+            collapsed=False,
+        )
+        # Float formatting with {:4.2f} should produce 2 decimal places
+        self.assertIn("5.25", result)
+        # Integer formatting with {} should work
+        self.assertIn("42", result)
+
+    def test_overhead_summary_data(self):
+        """Test with realistic overhead summary data."""
+        result = schedview.plot.html.markup_overhead_summary(self.overhead_summary, collapsed=False)
+        # All overhead statistics should be present
+        self.assertIn("Open shutter of first exposure", result)
+        self.assertIn("Close shutter of last exposure", result)
+        self.assertIn("Total wall clock time", result)
+        self.assertIn("Number of exposures", result)
+        self.assertIn("Total open shutter time", result)
+        self.assertIn("Mean gap time", result)
+        self.assertIn("Median gap time", result)
+
+    def test_collapsed_false_no_title(self):
+        """Test collapsed=False with empty title."""
+        result = schedview.plot.html.markup_mapping_with_format(
+            self.overhead_summary,
+            self.overhead_stat_name,
+            self.overhead_stat_str_template,
+            ["Number of exposures"],
+            "",
+            collapsed=False,
+        )
+        # Should contain formatted values
+        self.assertIn("15.50", result)
+        self.assertIn("42", result)
+        # Should not contain details/summary wrapper
+        self.assertNotIn("<details>", result)
+        self.assertNotIn("<summary>", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -243,5 +243,177 @@ class TestMarkupMappingWithFormat(unittest.TestCase):
         self.assertNotIn("<summary>", result)
 
 
+class TestMarkupSimIndexInfo(unittest.TestCase):
+    """Tests for markup_sim_index_info function."""
+
+    def setUp(self):
+        """Create test data matching real usage patterns."""
+        self.sim_index_info = pd.Series(
+            {
+                "visitseq_uuid": "abc-123-def",
+                "sim_creation_day_obs": "2024-08-15",
+                "daily_id": 1001,
+                "visitseq_label": "baseline_v2.0_10yrs",
+                "creation_time": "2024-08-15T12:00:00",
+                "telescope": "LSST",
+                "visitseq_url": "https://example.com/visitseq",
+                "config_url": "https://example.com/config",
+                "tags": "baseline,10yrs",
+            }
+        )
+        self.sim_index_info.files = {
+            "rewards": "https://example.com/rewards.h5",
+            "scheduler_pickle": "https://example.com/scheduler.pickle",
+        }
+
+    def test_collapsed_with_title(self):
+        """Test markup_sim_index_info with collapsed=True."""
+        result = schedview.plot.html.markup_sim_index_info(self.sim_index_info, collapsed=True)
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+        self.assertIn("baseline_v2.0_10yrs", result)
+        self.assertIn("LSST", result)
+        self.assertIn("abc-123-def", result)
+        self.assertIn("2024-08-15", result)
+
+
+class TestMarkupAdditionalSimFiles(unittest.TestCase):
+    """Tests for markup_additional_sim_files function."""
+
+    def setUp(self):
+        """Create test data matching real usage patterns."""
+        self.sim_index_info = pd.Series(
+            {
+                "visitseq_uuid": "abc-123-def",
+                "sim_creation_day_obs": "2024-08-15",
+            }
+        )
+        self.sim_index_info.files = {
+            "rewards": "https://example.com/rewards.h5",
+            "scheduler_pickle": "https://example.com/scheduler.pickle",
+        }
+
+    def test_collapsed_with_files(self):
+        """Test markup_additional_sim_files with collapsed=True."""
+        result = schedview.plot.html.markup_additional_sim_files(self.sim_index_info, collapsed=True)
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+        self.assertIn("Additional files available", result)
+        self.assertIn("rewards", result)
+        self.assertIn("scheduler_pickle", result)
+        self.assertIn("https://example.com/rewards.h5", result)
+
+
+class TestMarkupSimComments(unittest.TestCase):
+    """Tests for markup_sim_comments function."""
+
+    def setUp(self):
+        """Create test data matching real usage patterns."""
+        self.sim_info = pd.Series(
+            {
+                "visitseq_uuid": "abc-123-def",
+                "sim_creation_day_obs": "2024-08-15",
+            }
+        )
+        self.sim_info.comments = {
+            "2024-08-15T12:00:00": "First comment",
+            "2024-08-15T13:00:00": "Second comment",
+        }
+
+    def test_collapsed_with_comments(self):
+        """Test markup_sim_comments with collapsed=True."""
+        result = schedview.plot.html.markup_sim_comments(self.sim_info, collapsed=True)
+        # Should contain details/summary wrapper
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+        self.assertIn("Comments recorded in the simulation metadata database", result)
+        self.assertIn("First comment", result)
+        self.assertIn("Second comment", result)
+
+
+class TestMarkupNightEvents(unittest.TestCase):
+    """Tests for markup_night_events function."""
+
+    def setUp(self):
+        """Create test data matching real usage patterns."""
+        self.night_events = pd.DataFrame(
+            {
+                "UTC": [
+                    "2024-08-15T05:30:00",
+                    "2024-08-15T18:30:00",
+                    "2024-08-15T06:30:00",
+                    "2024-08-15T17:30:00",
+                    "2024-08-15T12:00:00",
+                ]
+            },
+            index=["sunset", "sunrise", "sun_n12_setting", "sun_n12_rising", "night_middle"],
+        )
+        # Convert strings to datetime objects
+        self.night_events["UTC"] = pd.to_datetime(self.night_events["UTC"])
+
+    def test_collapsed_with_title(self):
+        """Test markup_night_events with collapsed=True."""
+        result = schedview.plot.html.markup_night_events(self.night_events, collapsed=True)
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+        self.assertIn("Sunset:", result)
+        self.assertIn("Sunrise:", result)
+
+
+class TestMarkupSunMoonPositions(unittest.TestCase):
+    """Tests for markup_sun_moon_positions function."""
+
+    def setUp(self):
+        """Create test data matching real usage patterns."""
+        import numpy as np
+
+        # Position data in radians
+        self.sun_moon_positions = {
+            "sun_RA": np.radians(100.0),
+            "sun_dec": np.radians(20.0),
+            "sun_alt": np.radians(30.0),
+            "sun_az": np.radians(180.0),
+            "moon_RA": np.radians(150.0),
+            "moon_dec": np.radians(-10.0),
+            "moon_alt": np.radians(45.0),
+            "moon_az": np.radians(270.0),
+            "moon_phase": 50.0,
+        }
+
+    def test_collapsed_with_title(self):
+        """Test markup_sun_moon_positions with collapsed=True."""
+        result = schedview.plot.html.markup_sun_moon_positions(self.sun_moon_positions, collapsed=True)
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+        self.assertIn("Sun", result)
+        self.assertIn("Moon", result)
+
+
+class TestMarkupSurveyVisitSummary(unittest.TestCase):
+    """Tests for markup_survey_visit_summary function."""
+
+    def setUp(self):
+        """Create test data matching real usage patterns."""
+        self.survey_visit_summary = {
+            "n12_night_time": 10.5,
+            "n_survey_visits": 42,
+            "n_pairs_started": 15,
+            "n_pairs_finished": 12,
+            "ddfs_observed": 5,
+            "too_observed": 3,
+        }
+
+    def test_collapsed_with_title(self):
+        """Test markup_survey_visit_summary with collapsed=True."""
+        result = schedview.plot.html.markup_survey_visit_summary(self.survey_visit_summary, collapsed=True)
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+        self.assertIn("Number of survey visits", result)
+        self.assertIn("DDFs Observed", result)
+        self.assertIn("ToOs Observed", result)
+        self.assertIn("Time between 12 degree evening and morning twilights", result)
+        self.assertIn("Number of survey visits in night", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,135 @@
+import datetime
+import unittest
+from collections import namedtuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from astropy.time import Time
+
+import schedview
+import schedview.compute.astro
+import schedview.plot.html
+
+
+class TestConvertToHtml(unittest.TestCase):
+    """Tests for convert_to_html function."""
+
+    def test_with_string_content(self):
+        """Test convert_to_html with string content."""
+        content = "<p>This is a paragraph.</p>"
+        result = schedview.plot.html.convert_to_html(content, collapsed=False)
+        self.assertIn(content, result)
+
+    def test_with_string_content_collapsed_false(self):
+        """Test convert_to_html with string content and collapsed=False."""
+        content = "<p>This is a paragraph.</p>"
+        result = schedview.plot.html.convert_to_html(content, collapsed=False)
+        self.assertIn(content, result)
+        self.assertNotIn("<details>", result)
+        self.assertNotIn("<summary>", result)
+
+    def test_with_string_content_and_title(self):
+        """Test convert_to_html with string content and a title."""
+        content = "<p>This is a paragraph.</p>"
+        title = "Test Title"
+        result = schedview.plot.html.convert_to_html(content, title=title)
+        self.assertIn(title, result)
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+
+    def test_with_series(self):
+        """Test convert_to_html with pandas Series."""
+        series = pd.Series({"key1": "value1", "key2": "value2"}, name="values")
+        result = schedview.plot.html.convert_to_html(series, collapsed=False)
+        self.assertIn("key1", result)
+        self.assertIn("value1", result)
+        self.assertIn("<table", result)
+
+    def test_with_dataframe(self):
+        """Test convert_to_html with pandas DataFrame."""
+        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        result = schedview.plot.html.convert_to_html(df, collapsed=False)
+        self.assertIn("col1", result)
+        self.assertIn("col2", result)
+        self.assertIn("<table", result)
+
+    def test_with_figure(self):
+        """Test convert_to_html with matplotlib Figure."""
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+        result = schedview.plot.html.convert_to_html(fig, collapsed=False)
+        # Check that result contains image-related HTML (either img or svg)
+        self.assertTrue("<img" in result or "<svg" in result)
+        plt.close(fig)
+
+    def test_with_styler(self):
+        """Test convert_to_html with pandas Styler."""
+        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        styler = df.style.highlight_max(axis=0)
+        result = schedview.plot.html.convert_to_html(styler, collapsed=False)
+        self.assertIn("col1", result)
+        self.assertIn("col2", result)
+
+    def test_collapsed_true_without_title_raises(self):
+        """Test that collapsed=True without title raises ValueError."""
+        content = "some content"
+        with self.assertRaises(ValueError):
+            schedview.plot.html.convert_to_html(content, collapsed=True)
+
+    def test_collapsed_true_with_title(self):
+        """Test collapsed=True with title."""
+        content = "<p>content</p>"
+        title = "My Title"
+        result = schedview.plot.html.convert_to_html(content, title=title, collapsed=True)
+        self.assertIn("<details>", result)
+        self.assertIn("<summary>", result)
+        self.assertIn(title, result)
+
+    def test_collapsed_false_no_title(self):
+        """Test collapsed=False without title returns raw content."""
+        content = "<p>raw content</p>"
+        result = schedview.plot.html.convert_to_html(content, collapsed=False)
+        self.assertIn(content, result)
+        self.assertNotIn("<details>", result)
+
+    def test_collapsed_false_with_title(self):
+        """Test collapsed=False with title uses heading."""
+        content = "<p>content</p>"
+        title = "Section Title"
+        result = schedview.plot.html.convert_to_html(content, title=title, collapsed=False)
+        self.assertIn("<h3>", result)
+        self.assertIn(title, result)
+        self.assertIn(content, result)
+
+    def test_heading_level_1(self):
+        """Test heading level 1."""
+        content = "<p>content</p>"
+        title = "Title"
+        result = schedview.plot.html.convert_to_html(content, title=title, heading_level=1, collapsed=False)
+        self.assertIn("<h1>", result)
+
+    def test_heading_level_6(self):
+        """Test heading level 6."""
+        content = "<p>content</p>"
+        title = "Title"
+        result = schedview.plot.html.convert_to_html(content, title=title, heading_level=6, collapsed=False)
+        self.assertIn("<h6>", result)
+
+    def test_invalid_heading_level_raises(self):
+        """Test that invalid heading level raises AssertionError."""
+        content = "<p>content</p>"
+        with self.assertRaises(AssertionError):
+            schedview.plot.html.convert_to_html(content, heading_level=0)
+
+    def test_custom_pd_context_options(self):
+        """Test custom pandas context options."""
+        df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+        result = schedview.plot.html.convert_to_html(
+            df, pd_context_options=("display.width", 200), collapsed=False
+        )
+        self.assertIn("col1", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
You can see some of the results here:
 - https://usdf-rsp-int.slac.stanford.edu/schedview-static-pages/prenight/lsstcam/2026/04/14/prenight_2026-04-14.html
 - https://usdf-rsp-int.slac.stanford.edu/schedview-static-pages/nightsum/lsstcam/2026/04/13/nightsum_2026-04-13.html